### PR TITLE
fix: export generated C/C++ ABI symbols under hidden visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/conformance/c/producer.c
+++ b/conformance/c/producer.c
@@ -1,0 +1,67 @@
+// Producer-side conformance: a C backend that *implements* the generated C ABI
+// (rather than consuming a prebuilt library) must still export its symbols when
+// the shared library is built with hidden default visibility
+// (-fvisibility=hidden, the release-build norm and the MSVC default). The
+// generated header tags every prototype with the WEAVEFFI_API visibility macro,
+// so an implementing definition keeps default visibility and the symbol stays
+// exported. Without the macro the symbols would be hidden and unusable, exactly
+// the failure reported in https://github.com/weavefoundry/weaveffi/issues/23.
+//
+// This file implements every symbol the calculator header declares (the user
+// functions plus the runtime helpers a non-Rust producer also has to supply)
+// with trivial bodies, so it links as a self-contained shared library. The
+// harness then checks with `nm` that the symbols are exported.
+#include "weaveffi.h"
+
+int32_t weaveffi_calculator_add(int32_t a, int32_t b, weaveffi_error* out_err) {
+    (void)out_err;
+    return a + b;
+}
+
+int32_t weaveffi_calculator_mul(int32_t a, int32_t b, weaveffi_error* out_err) {
+    (void)out_err;
+    return a * b;
+}
+
+int32_t weaveffi_calculator_div(int32_t a, int32_t b, weaveffi_error* out_err) {
+    (void)out_err;
+    return b != 0 ? a / b : 0;
+}
+
+const char* weaveffi_calculator_echo(const char* s, weaveffi_error* out_err) {
+    (void)out_err;
+    return s;
+}
+
+void weaveffi_error_clear(weaveffi_error* err) {
+    if (err) {
+        err->code = 0;
+        err->message = 0;
+    }
+}
+
+void weaveffi_free_string(const char* ptr) {
+    (void)ptr;
+}
+
+void weaveffi_free_bytes(uint8_t* ptr, size_t len) {
+    (void)ptr;
+    (void)len;
+}
+
+weaveffi_cancel_token* weaveffi_cancel_token_create(void) {
+    return 0;
+}
+
+void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token) {
+    (void)token;
+}
+
+bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token) {
+    (void)token;
+    return false;
+}
+
+void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token) {
+    (void)token;
+}

--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -135,6 +135,31 @@ cpp_shapes() {
         && "$OUT/cpp_shapes"
 }
 
+# Producer lane: unlike every other lane (which *consumes* a prebuilt cdylib),
+# this compiles a C backend that *implements* the generated header into a shared
+# library under hidden default visibility (-fvisibility=hidden, the release norm
+# and the MSVC default). The generated header tags every prototype with the
+# WEAVEFFI_API visibility macro, so the implemented symbols stay exported; before
+# that macro existed they were hidden and unusable. Regression oracle for
+# https://github.com/weavefoundry/weaveffi/issues/23. Asserts both a user
+# function and a runtime helper are exported (defined + external) via `nm`.
+c_producer_exports() {
+    local incdir="$GENROOT/calculator/c"
+    local lib="$OUT/libcalc_producer.$EXT"
+    clang -shared -fPIC -fvisibility=hidden \
+        -I "$incdir" "$ROOT/conformance/c/producer.c" -o "$lib" \
+        || { echo "producer compile failed" >&2; return 1; }
+    local syms
+    syms=$(nm -g --defined-only "$lib" 2>/dev/null) || syms=$(nm -gU "$lib" 2>/dev/null)
+    for sym in weaveffi_calculator_add weaveffi_free_bytes; do
+        if ! printf '%s\n' "$syms" | grep -Eq "(^| )_?${sym}\$"; then
+            echo "symbol '$sym' not exported under hidden visibility from $lib" >&2
+            printf '%s\n' "$syms" | head -40 >&2
+            return 1
+        fi
+    done
+}
+
 # Resolve the platform-specific cdylib path for a sample crate.
 sample_lib() {
     case "$(uname)" in
@@ -447,6 +472,8 @@ build_producer kvstore
 generate kvstore samples/kvstore/kvstore.yml
 build_producer shapes
 generate shapes samples/shapes/shapes.yml
+# Header-only: the producer-export lane implements this in C, no Rust cdylib.
+generate calculator samples/calculator/calculator.yml
 
 # ---------------------------------------------------------------------------
 # Run matrix: every language runs the events lane (callbacks/listeners +
@@ -460,6 +487,7 @@ check cpp-events cpp_events
 check cpp-kvstore cpp_kvstore
 check c-shapes c_shapes
 check cpp-shapes cpp_shapes
+check c-producer-exports c_producer_exports
 check python-shapes python_shapes
 check ruby-shapes ruby_shapes
 check go-shapes go_shapes

--- a/crates/weaveffi-cli/tests/safety_audit.rs
+++ b/crates/weaveffi-cli/tests/safety_audit.rs
@@ -98,8 +98,11 @@ fn audit_c_string_ownership() {
     let const_char_fns: Vec<&str> = h
         .lines()
         .filter(|l| {
-            let t = l.trim();
-            t.starts_with("const char*") && t.contains('(') && t.ends_with(';')
+            // Every exported prototype is tagged with the `WEAVEFFI_API`
+            // visibility macro, with the `const char*` return type right after.
+            l.trim().strip_prefix("WEAVEFFI_API ").is_some_and(|t| {
+                t.starts_with("const char*") && t.contains('(') && t.ends_with(';')
+            })
         })
         .collect();
     assert!(

--- a/crates/weaveffi-cli/tests/snapshots/c_async_demo__weaveffi_h.snap
+++ b/crates/weaveffi-cli/tests/snapshots/c_async_demo__weaveffi_h.snap
@@ -12,6 +12,30 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,15 +44,15 @@ typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /*
  * Map convention: Maps are passed as parallel arrays of keys and values.
@@ -45,17 +69,17 @@ typedef void (*weaveffi_tasks_run_batch_callback)(void* context, weaveffi_error*
 typedef void (*weaveffi_tasks_run_n_tasks_callback)(void* context, weaveffi_error* err, int32_t result);
 
 // Module: tasks
-weaveffi_tasks_TaskResult* weaveffi_tasks_TaskResult_create(int64_t id, const char* value, bool success, weaveffi_error* out_err);
-void weaveffi_tasks_TaskResult_destroy(weaveffi_tasks_TaskResult* ptr);
-int64_t weaveffi_tasks_TaskResult_get_id(const weaveffi_tasks_TaskResult* ptr);
-const char* weaveffi_tasks_TaskResult_get_value(const weaveffi_tasks_TaskResult* ptr);
-bool weaveffi_tasks_TaskResult_get_success(const weaveffi_tasks_TaskResult* ptr);
+WEAVEFFI_API weaveffi_tasks_TaskResult* weaveffi_tasks_TaskResult_create(int64_t id, const char* value, bool success, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_tasks_TaskResult_destroy(weaveffi_tasks_TaskResult* ptr);
+WEAVEFFI_API int64_t weaveffi_tasks_TaskResult_get_id(const weaveffi_tasks_TaskResult* ptr);
+WEAVEFFI_API const char* weaveffi_tasks_TaskResult_get_value(const weaveffi_tasks_TaskResult* ptr);
+WEAVEFFI_API bool weaveffi_tasks_TaskResult_get_success(const weaveffi_tasks_TaskResult* ptr);
 
-void weaveffi_tasks_run_task_async(const char* name, weaveffi_tasks_run_task_callback callback, void* context);
-void weaveffi_tasks_run_batch_async(const char* const* names, size_t names_len, weaveffi_tasks_run_batch_callback callback, void* context);
-bool weaveffi_tasks_cancel_task(int64_t id, weaveffi_error* out_err);
-void weaveffi_tasks_run_n_tasks_async(int32_t n, weaveffi_tasks_run_n_tasks_callback callback, void* context);
-int64_t weaveffi_tasks_active_callbacks(weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_tasks_run_task_async(const char* name, weaveffi_tasks_run_task_callback callback, void* context);
+WEAVEFFI_API void weaveffi_tasks_run_batch_async(const char* const* names, size_t names_len, weaveffi_tasks_run_batch_callback callback, void* context);
+WEAVEFFI_API bool weaveffi_tasks_cancel_task(int64_t id, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_tasks_run_n_tasks_async(int32_t n, weaveffi_tasks_run_n_tasks_callback callback, void* context);
+WEAVEFFI_API int64_t weaveffi_tasks_active_callbacks(weaveffi_error* out_err);
 
 
 #ifdef __cplusplus

--- a/crates/weaveffi-cli/tests/snapshots/c_calculator__weaveffi_h.snap
+++ b/crates/weaveffi-cli/tests/snapshots/c_calculator__weaveffi_h.snap
@@ -12,6 +12,30 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,15 +44,15 @@ typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /*
  * Map convention: Maps are passed as parallel arrays of keys and values.
@@ -42,13 +66,13 @@ void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 // Module: calculator
 /** Add two integers */
-int32_t weaveffi_calculator_add(int32_t a, int32_t b, weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_calculator_add(int32_t a, int32_t b, weaveffi_error* out_err);
 /** Multiply two integers */
-int32_t weaveffi_calculator_mul(int32_t a, int32_t b, weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_calculator_mul(int32_t a, int32_t b, weaveffi_error* out_err);
 /** Divide two integers */
-int32_t weaveffi_calculator_div(int32_t a, int32_t b, weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_calculator_div(int32_t a, int32_t b, weaveffi_error* out_err);
 /** Echo a string back */
-const char* weaveffi_calculator_echo(const char* s, weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_calculator_echo(const char* s, weaveffi_error* out_err);
 
 
 #ifdef __cplusplus

--- a/crates/weaveffi-cli/tests/snapshots/c_contacts__weaveffi_h.snap
+++ b/crates/weaveffi-cli/tests/snapshots/c_contacts__weaveffi_h.snap
@@ -12,6 +12,30 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,15 +44,15 @@ typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /*
  * Map convention: Maps are passed as parallel arrays of keys and values.
@@ -43,19 +67,19 @@ typedef enum { weaveffi_contacts_ContactType_Personal = 0, weaveffi_contacts_Con
 typedef struct weaveffi_contacts_Contact weaveffi_contacts_Contact;
 
 // Module: contacts
-weaveffi_contacts_Contact* weaveffi_contacts_Contact_create(int64_t id, const char* first_name, const char* last_name, const char* email, weaveffi_contacts_ContactType contact_type, weaveffi_error* out_err);
-void weaveffi_contacts_Contact_destroy(weaveffi_contacts_Contact* ptr);
-int64_t weaveffi_contacts_Contact_get_id(const weaveffi_contacts_Contact* ptr);
-const char* weaveffi_contacts_Contact_get_first_name(const weaveffi_contacts_Contact* ptr);
-const char* weaveffi_contacts_Contact_get_last_name(const weaveffi_contacts_Contact* ptr);
-const char* weaveffi_contacts_Contact_get_email(const weaveffi_contacts_Contact* ptr);
-weaveffi_contacts_ContactType weaveffi_contacts_Contact_get_contact_type(const weaveffi_contacts_Contact* ptr);
+WEAVEFFI_API weaveffi_contacts_Contact* weaveffi_contacts_Contact_create(int64_t id, const char* first_name, const char* last_name, const char* email, weaveffi_contacts_ContactType contact_type, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_contacts_Contact_destroy(weaveffi_contacts_Contact* ptr);
+WEAVEFFI_API int64_t weaveffi_contacts_Contact_get_id(const weaveffi_contacts_Contact* ptr);
+WEAVEFFI_API const char* weaveffi_contacts_Contact_get_first_name(const weaveffi_contacts_Contact* ptr);
+WEAVEFFI_API const char* weaveffi_contacts_Contact_get_last_name(const weaveffi_contacts_Contact* ptr);
+WEAVEFFI_API const char* weaveffi_contacts_Contact_get_email(const weaveffi_contacts_Contact* ptr);
+WEAVEFFI_API weaveffi_contacts_ContactType weaveffi_contacts_Contact_get_contact_type(const weaveffi_contacts_Contact* ptr);
 
-weaveffi_handle_t weaveffi_contacts_create_contact(const char* first_name, const char* last_name, const char* email, weaveffi_contacts_ContactType contact_type, weaveffi_error* out_err);
-weaveffi_contacts_Contact* weaveffi_contacts_get_contact(weaveffi_handle_t id, weaveffi_error* out_err);
-weaveffi_contacts_Contact** weaveffi_contacts_list_contacts(size_t* out_len, weaveffi_error* out_err);
-bool weaveffi_contacts_delete_contact(weaveffi_handle_t id, weaveffi_error* out_err);
-int32_t weaveffi_contacts_count_contacts(weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_handle_t weaveffi_contacts_create_contact(const char* first_name, const char* last_name, const char* email, weaveffi_contacts_ContactType contact_type, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_contacts_Contact* weaveffi_contacts_get_contact(weaveffi_handle_t id, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_contacts_Contact** weaveffi_contacts_list_contacts(size_t* out_len, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_contacts_delete_contact(weaveffi_handle_t id, weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_contacts_count_contacts(weaveffi_error* out_err);
 
 
 #ifdef __cplusplus

--- a/crates/weaveffi-cli/tests/snapshots/c_docs_everywhere__weaveffi_h.snap
+++ b/crates/weaveffi-cli/tests/snapshots/c_docs_everywhere__weaveffi_h.snap
@@ -12,6 +12,30 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,15 +44,15 @@ typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /*
  * Map convention: Maps are passed as parallel arrays of keys and values.
@@ -64,44 +88,44 @@ typedef void (*weaveffi_docs_publish_async_callback)(void* context, weaveffi_err
  *
  * Documents are persisted to disk and exposed via the public API.
  */
-weaveffi_docs_Document* weaveffi_docs_Document_create(int64_t id, const char* title, weaveffi_docs_Status status, const char* const* tags, size_t tags_len, weaveffi_error* out_err);
-void weaveffi_docs_Document_destroy(weaveffi_docs_Document* ptr);
+WEAVEFFI_API weaveffi_docs_Document* weaveffi_docs_Document_create(int64_t id, const char* title, weaveffi_docs_Status status, const char* const* tags, size_t tags_len, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_docs_Document_destroy(weaveffi_docs_Document* ptr);
 /** Stable opaque identifier */
-int64_t weaveffi_docs_Document_get_id(const weaveffi_docs_Document* ptr);
+WEAVEFFI_API int64_t weaveffi_docs_Document_get_id(const weaveffi_docs_Document* ptr);
 /** Human-readable title shown in lists */
-const char* weaveffi_docs_Document_get_title(const weaveffi_docs_Document* ptr);
+WEAVEFFI_API const char* weaveffi_docs_Document_get_title(const weaveffi_docs_Document* ptr);
 /** Current lifecycle status */
-weaveffi_docs_Status weaveffi_docs_Document_get_status(const weaveffi_docs_Document* ptr);
+WEAVEFFI_API weaveffi_docs_Status weaveffi_docs_Document_get_status(const weaveffi_docs_Document* ptr);
 /** Free-form tags for grouping */
-const char** weaveffi_docs_Document_get_tags(const weaveffi_docs_Document* ptr, size_t* out_len);
+WEAVEFFI_API const char** weaveffi_docs_Document_get_tags(const weaveffi_docs_Document* ptr, size_t* out_len);
 
-weaveffi_docs_DocumentBuilder* weaveffi_docs_Document_Builder_new(void);
+WEAVEFFI_API weaveffi_docs_DocumentBuilder* weaveffi_docs_Document_Builder_new(void);
 /** Stable opaque identifier */
-void weaveffi_docs_Document_Builder_set_id(weaveffi_docs_DocumentBuilder* builder, int64_t id);
+WEAVEFFI_API void weaveffi_docs_Document_Builder_set_id(weaveffi_docs_DocumentBuilder* builder, int64_t id);
 /** Human-readable title shown in lists */
-void weaveffi_docs_Document_Builder_set_title(weaveffi_docs_DocumentBuilder* builder, const char* title);
+WEAVEFFI_API void weaveffi_docs_Document_Builder_set_title(weaveffi_docs_DocumentBuilder* builder, const char* title);
 /** Current lifecycle status */
-void weaveffi_docs_Document_Builder_set_status(weaveffi_docs_DocumentBuilder* builder, weaveffi_docs_Status status);
+WEAVEFFI_API void weaveffi_docs_Document_Builder_set_status(weaveffi_docs_DocumentBuilder* builder, weaveffi_docs_Status status);
 /** Free-form tags for grouping */
-void weaveffi_docs_Document_Builder_set_tags(weaveffi_docs_DocumentBuilder* builder, const char* const* tags, size_t tags_len);
-weaveffi_docs_Document* weaveffi_docs_Document_Builder_build(weaveffi_docs_DocumentBuilder* builder, weaveffi_error* out_err);
-void weaveffi_docs_Document_Builder_destroy(weaveffi_docs_DocumentBuilder* builder);
+WEAVEFFI_API void weaveffi_docs_Document_Builder_set_tags(weaveffi_docs_DocumentBuilder* builder, const char* const* tags, size_t tags_len);
+WEAVEFFI_API weaveffi_docs_Document* weaveffi_docs_Document_Builder_build(weaveffi_docs_DocumentBuilder* builder, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_docs_Document_Builder_destroy(weaveffi_docs_DocumentBuilder* builder);
 
 /** Subscribe to document-saved notifications */
-uint64_t weaveffi_docs_register_saved_listener(weaveffi_docs_OnSaved_fn callback, void* context);
+WEAVEFFI_API uint64_t weaveffi_docs_register_saved_listener(weaveffi_docs_OnSaved_fn callback, void* context);
 /** Subscribe to document-saved notifications */
-void weaveffi_docs_unregister_saved_listener(uint64_t id);
+WEAVEFFI_API void weaveffi_docs_unregister_saved_listener(uint64_t id);
 /**
  * Create a brand new document.
  *
  * The document starts in `Draft` status; callers must publish
  * it explicitly to make it visible.
  */
-weaveffi_docs_Document* weaveffi_docs_create_document(const char* title, const char* const* tags, size_t tags_len, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_docs_Document* weaveffi_docs_create_document(const char* title, const char* const* tags, size_t tags_len, weaveffi_error* out_err);
 /** Look up a document by identifier */
-weaveffi_docs_Document* weaveffi_docs_get_document(int64_t id, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_docs_Document* weaveffi_docs_get_document(int64_t id, weaveffi_error* out_err);
 /** Publish a document in the background */
-void weaveffi_docs_publish_async_async(int64_t id, weaveffi_docs_publish_async_callback callback, void* context);
+WEAVEFFI_API void weaveffi_docs_publish_async_async(int64_t id, weaveffi_docs_publish_async_callback callback, void* context);
 
 
 #ifdef __cplusplus

--- a/crates/weaveffi-cli/tests/snapshots/c_events__weaveffi_h.snap
+++ b/crates/weaveffi-cli/tests/snapshots/c_events__weaveffi_h.snap
@@ -12,6 +12,30 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,15 +44,15 @@ typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /*
  * Map convention: Maps are passed as parallel arrays of keys and values.
@@ -43,14 +67,14 @@ typedef struct weaveffi_events_GetMessagesIterator weaveffi_events_GetMessagesIt
 typedef void (*weaveffi_events_OnMessage_fn)(const char* message, void* context);
 
 // Module: events
-uint64_t weaveffi_events_register_message_listener(weaveffi_events_OnMessage_fn callback, void* context);
-void weaveffi_events_unregister_message_listener(uint64_t id);
+WEAVEFFI_API uint64_t weaveffi_events_register_message_listener(weaveffi_events_OnMessage_fn callback, void* context);
+WEAVEFFI_API void weaveffi_events_unregister_message_listener(uint64_t id);
 /** Send a message, triggering the OnMessage callback */
-void weaveffi_events_send_message(const char* text, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_events_send_message(const char* text, weaveffi_error* out_err);
 /** Return an iterator over all sent messages */
-weaveffi_events_GetMessagesIterator* weaveffi_events_get_messages(weaveffi_error* out_err);
-int32_t weaveffi_events_GetMessagesIterator_next(weaveffi_events_GetMessagesIterator* iter, const char** out_item, weaveffi_error* out_err);
-void weaveffi_events_GetMessagesIterator_destroy(weaveffi_events_GetMessagesIterator* iter);
+WEAVEFFI_API weaveffi_events_GetMessagesIterator* weaveffi_events_get_messages(weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_events_GetMessagesIterator_next(weaveffi_events_GetMessagesIterator* iter, const char** out_item, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_events_GetMessagesIterator_destroy(weaveffi_events_GetMessagesIterator* iter);
 
 
 #ifdef __cplusplus

--- a/crates/weaveffi-cli/tests/snapshots/c_inventory__weaveffi_h.snap
+++ b/crates/weaveffi-cli/tests/snapshots/c_inventory__weaveffi_h.snap
@@ -12,6 +12,30 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,15 +44,15 @@ typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /*
  * Map convention: Maps are passed as parallel arrays of keys and values.
@@ -45,39 +69,39 @@ typedef struct weaveffi_orders_OrderItem weaveffi_orders_OrderItem;
 typedef struct weaveffi_orders_Order weaveffi_orders_Order;
 
 // Module: products
-weaveffi_products_Product* weaveffi_products_Product_create(int64_t id, const char* name, const char* description, double price, weaveffi_products_Category category, const char* const* tags, size_t tags_len, weaveffi_error* out_err);
-void weaveffi_products_Product_destroy(weaveffi_products_Product* ptr);
-int64_t weaveffi_products_Product_get_id(const weaveffi_products_Product* ptr);
-const char* weaveffi_products_Product_get_name(const weaveffi_products_Product* ptr);
-const char* weaveffi_products_Product_get_description(const weaveffi_products_Product* ptr);
-double weaveffi_products_Product_get_price(const weaveffi_products_Product* ptr);
-weaveffi_products_Category weaveffi_products_Product_get_category(const weaveffi_products_Product* ptr);
-const char** weaveffi_products_Product_get_tags(const weaveffi_products_Product* ptr, size_t* out_len);
+WEAVEFFI_API weaveffi_products_Product* weaveffi_products_Product_create(int64_t id, const char* name, const char* description, double price, weaveffi_products_Category category, const char* const* tags, size_t tags_len, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_products_Product_destroy(weaveffi_products_Product* ptr);
+WEAVEFFI_API int64_t weaveffi_products_Product_get_id(const weaveffi_products_Product* ptr);
+WEAVEFFI_API const char* weaveffi_products_Product_get_name(const weaveffi_products_Product* ptr);
+WEAVEFFI_API const char* weaveffi_products_Product_get_description(const weaveffi_products_Product* ptr);
+WEAVEFFI_API double weaveffi_products_Product_get_price(const weaveffi_products_Product* ptr);
+WEAVEFFI_API weaveffi_products_Category weaveffi_products_Product_get_category(const weaveffi_products_Product* ptr);
+WEAVEFFI_API const char** weaveffi_products_Product_get_tags(const weaveffi_products_Product* ptr, size_t* out_len);
 
-weaveffi_handle_t weaveffi_products_create_product(const char* name, double price, weaveffi_products_Category category, weaveffi_error* out_err);
-weaveffi_products_Product* weaveffi_products_get_product(weaveffi_handle_t id, weaveffi_error* out_err);
-weaveffi_products_Product** weaveffi_products_search_products(weaveffi_products_Category category, size_t* out_len, weaveffi_error* out_err);
-bool weaveffi_products_update_price(weaveffi_handle_t id, double price, weaveffi_error* out_err);
-bool weaveffi_products_delete_product(weaveffi_handle_t id, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_handle_t weaveffi_products_create_product(const char* name, double price, weaveffi_products_Category category, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_products_Product* weaveffi_products_get_product(weaveffi_handle_t id, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_products_Product** weaveffi_products_search_products(weaveffi_products_Category category, size_t* out_len, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_products_update_price(weaveffi_handle_t id, double price, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_products_delete_product(weaveffi_handle_t id, weaveffi_error* out_err);
 
 // Module: orders
-weaveffi_orders_OrderItem* weaveffi_orders_OrderItem_create(int64_t product_id, int32_t quantity, double unit_price, weaveffi_error* out_err);
-void weaveffi_orders_OrderItem_destroy(weaveffi_orders_OrderItem* ptr);
-int64_t weaveffi_orders_OrderItem_get_product_id(const weaveffi_orders_OrderItem* ptr);
-int32_t weaveffi_orders_OrderItem_get_quantity(const weaveffi_orders_OrderItem* ptr);
-double weaveffi_orders_OrderItem_get_unit_price(const weaveffi_orders_OrderItem* ptr);
+WEAVEFFI_API weaveffi_orders_OrderItem* weaveffi_orders_OrderItem_create(int64_t product_id, int32_t quantity, double unit_price, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_orders_OrderItem_destroy(weaveffi_orders_OrderItem* ptr);
+WEAVEFFI_API int64_t weaveffi_orders_OrderItem_get_product_id(const weaveffi_orders_OrderItem* ptr);
+WEAVEFFI_API int32_t weaveffi_orders_OrderItem_get_quantity(const weaveffi_orders_OrderItem* ptr);
+WEAVEFFI_API double weaveffi_orders_OrderItem_get_unit_price(const weaveffi_orders_OrderItem* ptr);
 
-weaveffi_orders_Order* weaveffi_orders_Order_create(int64_t id, weaveffi_orders_OrderItem* const* items, size_t items_len, double total, const char* status, weaveffi_error* out_err);
-void weaveffi_orders_Order_destroy(weaveffi_orders_Order* ptr);
-int64_t weaveffi_orders_Order_get_id(const weaveffi_orders_Order* ptr);
-weaveffi_orders_OrderItem** weaveffi_orders_Order_get_items(const weaveffi_orders_Order* ptr, size_t* out_len);
-double weaveffi_orders_Order_get_total(const weaveffi_orders_Order* ptr);
-const char* weaveffi_orders_Order_get_status(const weaveffi_orders_Order* ptr);
+WEAVEFFI_API weaveffi_orders_Order* weaveffi_orders_Order_create(int64_t id, weaveffi_orders_OrderItem* const* items, size_t items_len, double total, const char* status, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_orders_Order_destroy(weaveffi_orders_Order* ptr);
+WEAVEFFI_API int64_t weaveffi_orders_Order_get_id(const weaveffi_orders_Order* ptr);
+WEAVEFFI_API weaveffi_orders_OrderItem** weaveffi_orders_Order_get_items(const weaveffi_orders_Order* ptr, size_t* out_len);
+WEAVEFFI_API double weaveffi_orders_Order_get_total(const weaveffi_orders_Order* ptr);
+WEAVEFFI_API const char* weaveffi_orders_Order_get_status(const weaveffi_orders_Order* ptr);
 
-weaveffi_handle_t weaveffi_orders_create_order(weaveffi_orders_OrderItem* const* items, size_t items_len, weaveffi_error* out_err);
-weaveffi_orders_Order* weaveffi_orders_get_order(weaveffi_handle_t id, weaveffi_error* out_err);
-bool weaveffi_orders_cancel_order(weaveffi_handle_t id, weaveffi_error* out_err);
-bool weaveffi_orders_add_product_to_order(weaveffi_handle_t order_id, const weaveffi_products_Product* product, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_handle_t weaveffi_orders_create_order(weaveffi_orders_OrderItem* const* items, size_t items_len, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_orders_Order* weaveffi_orders_get_order(weaveffi_handle_t id, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_orders_cancel_order(weaveffi_handle_t id, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_orders_add_product_to_order(weaveffi_handle_t order_id, const weaveffi_products_Product* product, weaveffi_error* out_err);
 
 
 #ifdef __cplusplus

--- a/crates/weaveffi-cli/tests/snapshots/c_kitchen_sink__weaveffi_h.snap
+++ b/crates/weaveffi-cli/tests/snapshots/c_kitchen_sink__weaveffi_h.snap
@@ -12,6 +12,30 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,15 +44,15 @@ typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /*
  * Map convention: Maps are passed as parallel arrays of keys and values.
@@ -59,104 +83,104 @@ typedef void (*weaveffi_kitchen_do_cancellable_callback)(void* context, weaveffi
 
 // Module: shared
 /** A reusable token referenced across modules */
-weaveffi_shared_Token* weaveffi_shared_Token_create(int64_t id, const char* label, weaveffi_error* out_err);
-void weaveffi_shared_Token_destroy(weaveffi_shared_Token* ptr);
-int64_t weaveffi_shared_Token_get_id(const weaveffi_shared_Token* ptr);
-const char* weaveffi_shared_Token_get_label(const weaveffi_shared_Token* ptr);
+WEAVEFFI_API weaveffi_shared_Token* weaveffi_shared_Token_create(int64_t id, const char* label, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_shared_Token_destroy(weaveffi_shared_Token* ptr);
+WEAVEFFI_API int64_t weaveffi_shared_Token_get_id(const weaveffi_shared_Token* ptr);
+WEAVEFFI_API const char* weaveffi_shared_Token_get_label(const weaveffi_shared_Token* ptr);
 
 /** Trivial cross-module helper */
-const char* weaveffi_shared_ping(weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_shared_ping(weaveffi_error* out_err);
 
 // Module: kitchen
 /** Kitchen sink struct exercising every field feature */
-weaveffi_kitchen_Item* weaveffi_kitchen_Item_create(int64_t id, const char* name, int32_t count, bool enabled, double ratio, uint32_t nick, const uint8_t* payload_ptr, size_t payload_len, const char* const* tags, size_t tags_len, const char* const* attrs_keys, const char* const* attrs_values, size_t attrs_len, const int64_t* parent, const weaveffi_shared_Token* token, weaveffi_kitchen_Priority priority, weaveffi_error* out_err);
-void weaveffi_kitchen_Item_destroy(weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API weaveffi_kitchen_Item* weaveffi_kitchen_Item_create(int64_t id, const char* name, int32_t count, bool enabled, double ratio, uint32_t nick, const uint8_t* payload_ptr, size_t payload_len, const char* const* tags, size_t tags_len, const char* const* attrs_keys, const char* const* attrs_values, size_t attrs_len, const int64_t* parent, const weaveffi_shared_Token* token, weaveffi_kitchen_Priority priority, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kitchen_Item_destroy(weaveffi_kitchen_Item* ptr);
 /** Stable identifier */
-int64_t weaveffi_kitchen_Item_get_id(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API int64_t weaveffi_kitchen_Item_get_id(const weaveffi_kitchen_Item* ptr);
 /** Display name */
-const char* weaveffi_kitchen_Item_get_name(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API const char* weaveffi_kitchen_Item_get_name(const weaveffi_kitchen_Item* ptr);
 /** Initial count */
-int32_t weaveffi_kitchen_Item_get_count(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API int32_t weaveffi_kitchen_Item_get_count(const weaveffi_kitchen_Item* ptr);
 /** Whether the item is enabled */
-bool weaveffi_kitchen_Item_get_enabled(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API bool weaveffi_kitchen_Item_get_enabled(const weaveffi_kitchen_Item* ptr);
 /** Scaling ratio */
-double weaveffi_kitchen_Item_get_ratio(const weaveffi_kitchen_Item* ptr);
-uint32_t weaveffi_kitchen_Item_get_nick(const weaveffi_kitchen_Item* ptr);
-const uint8_t* weaveffi_kitchen_Item_get_payload(const weaveffi_kitchen_Item* ptr, size_t* out_len);
-const char** weaveffi_kitchen_Item_get_tags(const weaveffi_kitchen_Item* ptr, size_t* out_len);
-void weaveffi_kitchen_Item_get_attrs(const weaveffi_kitchen_Item* ptr, const char*** out_keys, const char*** out_values, size_t* out_len);
-int64_t* weaveffi_kitchen_Item_get_parent(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API double weaveffi_kitchen_Item_get_ratio(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API uint32_t weaveffi_kitchen_Item_get_nick(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API const uint8_t* weaveffi_kitchen_Item_get_payload(const weaveffi_kitchen_Item* ptr, size_t* out_len);
+WEAVEFFI_API const char** weaveffi_kitchen_Item_get_tags(const weaveffi_kitchen_Item* ptr, size_t* out_len);
+WEAVEFFI_API void weaveffi_kitchen_Item_get_attrs(const weaveffi_kitchen_Item* ptr, const char*** out_keys, const char*** out_values, size_t* out_len);
+WEAVEFFI_API int64_t* weaveffi_kitchen_Item_get_parent(const weaveffi_kitchen_Item* ptr);
 /** Cross-module struct reference */
-weaveffi_shared_Token* weaveffi_kitchen_Item_get_token(const weaveffi_kitchen_Item* ptr);
-weaveffi_kitchen_Priority weaveffi_kitchen_Item_get_priority(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API weaveffi_shared_Token* weaveffi_kitchen_Item_get_token(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API weaveffi_kitchen_Priority weaveffi_kitchen_Item_get_priority(const weaveffi_kitchen_Item* ptr);
 
-weaveffi_kitchen_ItemBuilder* weaveffi_kitchen_Item_Builder_new(void);
+WEAVEFFI_API weaveffi_kitchen_ItemBuilder* weaveffi_kitchen_Item_Builder_new(void);
 /** Stable identifier */
-void weaveffi_kitchen_Item_Builder_set_id(weaveffi_kitchen_ItemBuilder* builder, int64_t id);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_id(weaveffi_kitchen_ItemBuilder* builder, int64_t id);
 /** Display name */
-void weaveffi_kitchen_Item_Builder_set_name(weaveffi_kitchen_ItemBuilder* builder, const char* name);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_name(weaveffi_kitchen_ItemBuilder* builder, const char* name);
 /** Initial count */
-void weaveffi_kitchen_Item_Builder_set_count(weaveffi_kitchen_ItemBuilder* builder, int32_t count);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_count(weaveffi_kitchen_ItemBuilder* builder, int32_t count);
 /** Whether the item is enabled */
-void weaveffi_kitchen_Item_Builder_set_enabled(weaveffi_kitchen_ItemBuilder* builder, bool enabled);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_enabled(weaveffi_kitchen_ItemBuilder* builder, bool enabled);
 /** Scaling ratio */
-void weaveffi_kitchen_Item_Builder_set_ratio(weaveffi_kitchen_ItemBuilder* builder, double ratio);
-void weaveffi_kitchen_Item_Builder_set_nick(weaveffi_kitchen_ItemBuilder* builder, uint32_t nick);
-void weaveffi_kitchen_Item_Builder_set_payload(weaveffi_kitchen_ItemBuilder* builder, const uint8_t* payload_ptr, size_t payload_len);
-void weaveffi_kitchen_Item_Builder_set_tags(weaveffi_kitchen_ItemBuilder* builder, const char* const* tags, size_t tags_len);
-void weaveffi_kitchen_Item_Builder_set_attrs(weaveffi_kitchen_ItemBuilder* builder, const char* const* attrs_keys, const char* const* attrs_values, size_t attrs_len);
-void weaveffi_kitchen_Item_Builder_set_parent(weaveffi_kitchen_ItemBuilder* builder, const int64_t* parent);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_ratio(weaveffi_kitchen_ItemBuilder* builder, double ratio);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_nick(weaveffi_kitchen_ItemBuilder* builder, uint32_t nick);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_payload(weaveffi_kitchen_ItemBuilder* builder, const uint8_t* payload_ptr, size_t payload_len);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_tags(weaveffi_kitchen_ItemBuilder* builder, const char* const* tags, size_t tags_len);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_attrs(weaveffi_kitchen_ItemBuilder* builder, const char* const* attrs_keys, const char* const* attrs_values, size_t attrs_len);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_parent(weaveffi_kitchen_ItemBuilder* builder, const int64_t* parent);
 /** Cross-module struct reference */
-void weaveffi_kitchen_Item_Builder_set_token(weaveffi_kitchen_ItemBuilder* builder, const weaveffi_shared_Token* token);
-void weaveffi_kitchen_Item_Builder_set_priority(weaveffi_kitchen_ItemBuilder* builder, weaveffi_kitchen_Priority priority);
-weaveffi_kitchen_Item* weaveffi_kitchen_Item_Builder_build(weaveffi_kitchen_ItemBuilder* builder, weaveffi_error* out_err);
-void weaveffi_kitchen_Item_Builder_destroy(weaveffi_kitchen_ItemBuilder* builder);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_token(weaveffi_kitchen_ItemBuilder* builder, const weaveffi_shared_Token* token);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_priority(weaveffi_kitchen_ItemBuilder* builder, weaveffi_kitchen_Priority priority);
+WEAVEFFI_API weaveffi_kitchen_Item* weaveffi_kitchen_Item_Builder_build(weaveffi_kitchen_ItemBuilder* builder, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_destroy(weaveffi_kitchen_ItemBuilder* builder);
 
 /** Subscribe to OnReady events */
-uint64_t weaveffi_kitchen_register_ready_listener(weaveffi_kitchen_OnReady_fn callback, void* context);
+WEAVEFFI_API uint64_t weaveffi_kitchen_register_ready_listener(weaveffi_kitchen_OnReady_fn callback, void* context);
 /** Subscribe to OnReady events */
-void weaveffi_kitchen_unregister_ready_listener(uint64_t id);
+WEAVEFFI_API void weaveffi_kitchen_unregister_ready_listener(uint64_t id);
 /** Identity for bool */
-bool weaveffi_kitchen_bool_id(bool x, weaveffi_error* out_err);
-int32_t weaveffi_kitchen_i32_id(int32_t x, weaveffi_error* out_err);
-uint32_t weaveffi_kitchen_u32_id(uint32_t x, weaveffi_error* out_err);
-int64_t weaveffi_kitchen_i64_id(int64_t x, weaveffi_error* out_err);
-double weaveffi_kitchen_f64_id(double x, weaveffi_error* out_err);
-const char* weaveffi_kitchen_echo_string(const char* s, weaveffi_error* out_err);
-const uint8_t* weaveffi_kitchen_echo_bytes(const uint8_t* b_ptr, size_t b_len, size_t* out_len, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_kitchen_bool_id(bool x, weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_kitchen_i32_id(int32_t x, weaveffi_error* out_err);
+WEAVEFFI_API uint32_t weaveffi_kitchen_u32_id(uint32_t x, weaveffi_error* out_err);
+WEAVEFFI_API int64_t weaveffi_kitchen_i64_id(int64_t x, weaveffi_error* out_err);
+WEAVEFFI_API double weaveffi_kitchen_f64_id(double x, weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_kitchen_echo_string(const char* s, weaveffi_error* out_err);
+WEAVEFFI_API const uint8_t* weaveffi_kitchen_echo_bytes(const uint8_t* b_ptr, size_t b_len, size_t* out_len, weaveffi_error* out_err);
 /** Borrowed string parameter */
-const char* weaveffi_kitchen_echo_borrowed_str(const char* s, weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_kitchen_echo_borrowed_str(const char* s, weaveffi_error* out_err);
 /** Borrowed bytes parameter */
-const uint8_t* weaveffi_kitchen_echo_borrowed_bytes(const uint8_t* b_ptr, size_t b_len, size_t* out_len, weaveffi_error* out_err);
+WEAVEFFI_API const uint8_t* weaveffi_kitchen_echo_borrowed_bytes(const uint8_t* b_ptr, size_t b_len, size_t* out_len, weaveffi_error* out_err);
 /** Returns an opaque handle */
-weaveffi_handle_t weaveffi_kitchen_open_handle(weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_handle_t weaveffi_kitchen_open_handle(weaveffi_error* out_err);
 /** Returns a typed handle */
-weaveffi_shared_Token* weaveffi_kitchen_open_typed_handle(weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_shared_Token* weaveffi_kitchen_open_typed_handle(weaveffi_error* out_err);
 /** Optional struct return */
-weaveffi_kitchen_Item* weaveffi_kitchen_maybe_item(int64_t id, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_kitchen_Item* weaveffi_kitchen_maybe_item(int64_t id, weaveffi_error* out_err);
 /** List of structs */
-weaveffi_kitchen_Item** weaveffi_kitchen_list_items(size_t* out_len, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_kitchen_Item** weaveffi_kitchen_list_items(size_t* out_len, weaveffi_error* out_err);
 /** Map return type */
-void weaveffi_kitchen_get_attrs(const char*** out_keys, int32_t** out_values, size_t* out_len, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kitchen_get_attrs(const char*** out_keys, int32_t** out_values, size_t* out_len, weaveffi_error* out_err);
 /** Iterator return type */
-weaveffi_kitchen_StreamItemsIterator* weaveffi_kitchen_stream_items(weaveffi_error* out_err);
-int32_t weaveffi_kitchen_StreamItemsIterator_next(weaveffi_kitchen_StreamItemsIterator* iter, weaveffi_kitchen_Item** out_item, weaveffi_error* out_err);
-void weaveffi_kitchen_StreamItemsIterator_destroy(weaveffi_kitchen_StreamItemsIterator* iter);
+WEAVEFFI_API weaveffi_kitchen_StreamItemsIterator* weaveffi_kitchen_stream_items(weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_kitchen_StreamItemsIterator_next(weaveffi_kitchen_StreamItemsIterator* iter, weaveffi_kitchen_Item** out_item, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kitchen_StreamItemsIterator_destroy(weaveffi_kitchen_StreamItemsIterator* iter);
 /** Returns the shared Token type from another module */
-weaveffi_shared_Token* weaveffi_kitchen_cross_module_token(weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_shared_Token* weaveffi_kitchen_cross_module_token(weaveffi_error* out_err);
 /** Async operation */
-void weaveffi_kitchen_do_async_async(const char* input, weaveffi_kitchen_do_async_callback callback, void* context);
+WEAVEFFI_API void weaveffi_kitchen_do_async_async(const char* input, weaveffi_kitchen_do_async_callback callback, void* context);
 /** Cancellable async operation */
-void weaveffi_kitchen_do_cancellable_async(const char* input, weaveffi_cancel_token* cancel_token, weaveffi_kitchen_do_cancellable_callback callback, void* context);
+WEAVEFFI_API void weaveffi_kitchen_do_cancellable_async(const char* input, weaveffi_cancel_token* cancel_token, weaveffi_kitchen_do_cancellable_callback callback, void* context);
 /** Legacy operation kept for compatibility */
-__attribute__((deprecated("Use new_op instead")))
-int32_t weaveffi_kitchen_legacy_op(weaveffi_error* out_err);
+WEAVEFFI_DEPRECATED("Use new_op instead")
+WEAVEFFI_API int32_t weaveffi_kitchen_legacy_op(weaveffi_error* out_err);
 /** Replacement for legacy_op */
-int32_t weaveffi_kitchen_new_op(weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_kitchen_new_op(weaveffi_error* out_err);
 
 // Module: kitchen_nested
 /** Trivial nested-module function */
-const char* weaveffi_kitchen_nested_hello(weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_kitchen_nested_hello(weaveffi_error* out_err);
 
 
 #ifdef __cplusplus

--- a/crates/weaveffi-cli/tests/snapshots/c_kvstore__weaveffi_h.snap
+++ b/crates/weaveffi-cli/tests/snapshots/c_kvstore__weaveffi_h.snap
@@ -12,6 +12,30 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,15 +44,15 @@ typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /*
  * Map convention: Maps are passed as parallel arrays of keys and values.
@@ -59,88 +83,88 @@ typedef void (*weaveffi_kv_compact_async_callback)(void* context, weaveffi_error
 
 // Module: kv
 /** Opaque key-value store handle target type */
-weaveffi_kv_Store* weaveffi_kv_Store_create(int64_t id, weaveffi_error* out_err);
-void weaveffi_kv_Store_destroy(weaveffi_kv_Store* ptr);
+WEAVEFFI_API weaveffi_kv_Store* weaveffi_kv_Store_create(int64_t id, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_Store_destroy(weaveffi_kv_Store* ptr);
 /** Internal store identifier */
-int64_t weaveffi_kv_Store_get_id(const weaveffi_kv_Store* ptr);
+WEAVEFFI_API int64_t weaveffi_kv_Store_get_id(const weaveffi_kv_Store* ptr);
 
 /** A single key-value entry persisted in the store */
-weaveffi_kv_Entry* weaveffi_kv_Entry_create(int64_t id, const char* key, const uint8_t* value_ptr, size_t value_len, int64_t created_at, const int64_t* expires_at, const char* const* tags, size_t tags_len, const char* const* metadata_keys, const char* const* metadata_values, size_t metadata_len, weaveffi_error* out_err);
-void weaveffi_kv_Entry_destroy(weaveffi_kv_Entry* ptr);
+WEAVEFFI_API weaveffi_kv_Entry* weaveffi_kv_Entry_create(int64_t id, const char* key, const uint8_t* value_ptr, size_t value_len, int64_t created_at, const int64_t* expires_at, const char* const* tags, size_t tags_len, const char* const* metadata_keys, const char* const* metadata_values, size_t metadata_len, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_Entry_destroy(weaveffi_kv_Entry* ptr);
 /** Stable monotonic identifier assigned on insert */
-int64_t weaveffi_kv_Entry_get_id(const weaveffi_kv_Entry* ptr);
+WEAVEFFI_API int64_t weaveffi_kv_Entry_get_id(const weaveffi_kv_Entry* ptr);
 /** UTF-8 lookup key */
-const char* weaveffi_kv_Entry_get_key(const weaveffi_kv_Entry* ptr);
+WEAVEFFI_API const char* weaveffi_kv_Entry_get_key(const weaveffi_kv_Entry* ptr);
 /** Opaque binary payload */
-const uint8_t* weaveffi_kv_Entry_get_value(const weaveffi_kv_Entry* ptr, size_t* out_len);
+WEAVEFFI_API const uint8_t* weaveffi_kv_Entry_get_value(const weaveffi_kv_Entry* ptr, size_t* out_len);
 /** Unix-timestamp seconds when the entry was created */
-int64_t weaveffi_kv_Entry_get_created_at(const weaveffi_kv_Entry* ptr);
+WEAVEFFI_API int64_t weaveffi_kv_Entry_get_created_at(const weaveffi_kv_Entry* ptr);
 /** Optional unix-timestamp seconds at which the entry expires */
-int64_t* weaveffi_kv_Entry_get_expires_at(const weaveffi_kv_Entry* ptr);
+WEAVEFFI_API int64_t* weaveffi_kv_Entry_get_expires_at(const weaveffi_kv_Entry* ptr);
 /** Free-form labels attached to the entry */
-const char** weaveffi_kv_Entry_get_tags(const weaveffi_kv_Entry* ptr, size_t* out_len);
+WEAVEFFI_API const char** weaveffi_kv_Entry_get_tags(const weaveffi_kv_Entry* ptr, size_t* out_len);
 /** Arbitrary string-valued metadata pairs */
-void weaveffi_kv_Entry_get_metadata(const weaveffi_kv_Entry* ptr, const char*** out_keys, const char*** out_values, size_t* out_len);
+WEAVEFFI_API void weaveffi_kv_Entry_get_metadata(const weaveffi_kv_Entry* ptr, const char*** out_keys, const char*** out_values, size_t* out_len);
 
-weaveffi_kv_EntryBuilder* weaveffi_kv_Entry_Builder_new(void);
+WEAVEFFI_API weaveffi_kv_EntryBuilder* weaveffi_kv_Entry_Builder_new(void);
 /** Stable monotonic identifier assigned on insert */
-void weaveffi_kv_Entry_Builder_set_id(weaveffi_kv_EntryBuilder* builder, int64_t id);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_id(weaveffi_kv_EntryBuilder* builder, int64_t id);
 /** UTF-8 lookup key */
-void weaveffi_kv_Entry_Builder_set_key(weaveffi_kv_EntryBuilder* builder, const char* key);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_key(weaveffi_kv_EntryBuilder* builder, const char* key);
 /** Opaque binary payload */
-void weaveffi_kv_Entry_Builder_set_value(weaveffi_kv_EntryBuilder* builder, const uint8_t* value_ptr, size_t value_len);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_value(weaveffi_kv_EntryBuilder* builder, const uint8_t* value_ptr, size_t value_len);
 /** Unix-timestamp seconds when the entry was created */
-void weaveffi_kv_Entry_Builder_set_created_at(weaveffi_kv_EntryBuilder* builder, int64_t created_at);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_created_at(weaveffi_kv_EntryBuilder* builder, int64_t created_at);
 /** Optional unix-timestamp seconds at which the entry expires */
-void weaveffi_kv_Entry_Builder_set_expires_at(weaveffi_kv_EntryBuilder* builder, const int64_t* expires_at);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_expires_at(weaveffi_kv_EntryBuilder* builder, const int64_t* expires_at);
 /** Free-form labels attached to the entry */
-void weaveffi_kv_Entry_Builder_set_tags(weaveffi_kv_EntryBuilder* builder, const char* const* tags, size_t tags_len);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_tags(weaveffi_kv_EntryBuilder* builder, const char* const* tags, size_t tags_len);
 /** Arbitrary string-valued metadata pairs */
-void weaveffi_kv_Entry_Builder_set_metadata(weaveffi_kv_EntryBuilder* builder, const char* const* metadata_keys, const char* const* metadata_values, size_t metadata_len);
-weaveffi_kv_Entry* weaveffi_kv_Entry_Builder_build(weaveffi_kv_EntryBuilder* builder, weaveffi_error* out_err);
-void weaveffi_kv_Entry_Builder_destroy(weaveffi_kv_EntryBuilder* builder);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_metadata(weaveffi_kv_EntryBuilder* builder, const char* const* metadata_keys, const char* const* metadata_values, size_t metadata_len);
+WEAVEFFI_API weaveffi_kv_Entry* weaveffi_kv_Entry_Builder_build(weaveffi_kv_EntryBuilder* builder, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_destroy(weaveffi_kv_EntryBuilder* builder);
 
 /** Subscribe to per-key eviction notifications */
-uint64_t weaveffi_kv_register_eviction_listener(weaveffi_kv_OnEvict_fn callback, void* context);
+WEAVEFFI_API uint64_t weaveffi_kv_register_eviction_listener(weaveffi_kv_OnEvict_fn callback, void* context);
 /** Subscribe to per-key eviction notifications */
-void weaveffi_kv_unregister_eviction_listener(uint64_t id);
+WEAVEFFI_API void weaveffi_kv_unregister_eviction_listener(uint64_t id);
 /** Open (or create) a store backed by the given filesystem path */
-weaveffi_kv_Store* weaveffi_kv_open_store(const char* path, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_kv_Store* weaveffi_kv_open_store(const char* path, weaveffi_error* out_err);
 /** Close the store and release all in-memory resources */
-void weaveffi_kv_close_store(weaveffi_kv_Store* store, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_close_store(weaveffi_kv_Store* store, weaveffi_error* out_err);
 /** Insert or replace a value, returning true on success */
-bool weaveffi_kv_put(weaveffi_kv_Store* store, const char* key, const uint8_t* value_ptr, size_t value_len, weaveffi_kv_EntryKind kind, const int64_t* ttl_seconds, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_kv_put(weaveffi_kv_Store* store, const char* key, const uint8_t* value_ptr, size_t value_len, weaveffi_kv_EntryKind kind, const int64_t* ttl_seconds, weaveffi_error* out_err);
 /** Look up an entry by key; returns null if missing or expired */
-weaveffi_kv_Entry* weaveffi_kv_get(weaveffi_kv_Store* store, const char* key, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_kv_Entry* weaveffi_kv_get(weaveffi_kv_Store* store, const char* key, weaveffi_error* out_err);
 /** Remove the entry for the given key, returning true if it existed */
-bool weaveffi_kv_delete(weaveffi_kv_Store* store, const char* key, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_kv_delete(weaveffi_kv_Store* store, const char* key, weaveffi_error* out_err);
 /** Stream every key, optionally filtered by a prefix */
-weaveffi_kv_ListKeysIterator* weaveffi_kv_list_keys(weaveffi_kv_Store* store, const char* prefix, weaveffi_error* out_err);
-int32_t weaveffi_kv_ListKeysIterator_next(weaveffi_kv_ListKeysIterator* iter, const char** out_item, weaveffi_error* out_err);
-void weaveffi_kv_ListKeysIterator_destroy(weaveffi_kv_ListKeysIterator* iter);
+WEAVEFFI_API weaveffi_kv_ListKeysIterator* weaveffi_kv_list_keys(weaveffi_kv_Store* store, const char* prefix, weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_kv_ListKeysIterator_next(weaveffi_kv_ListKeysIterator* iter, const char** out_item, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_ListKeysIterator_destroy(weaveffi_kv_ListKeysIterator* iter);
 /** Return the number of live entries in the store */
-int64_t weaveffi_kv_count(weaveffi_kv_Store* store, weaveffi_error* out_err);
+WEAVEFFI_API int64_t weaveffi_kv_count(weaveffi_kv_Store* store, weaveffi_error* out_err);
 /** Drop every entry from the store */
-void weaveffi_kv_clear(weaveffi_kv_Store* store, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_clear(weaveffi_kv_Store* store, weaveffi_error* out_err);
 /** Reclaim space asynchronously; returns the number of bytes reclaimed */
-void weaveffi_kv_compact_async_async(weaveffi_kv_Store* store, weaveffi_cancel_token* cancel_token, weaveffi_kv_compact_async_callback callback, void* context);
+WEAVEFFI_API void weaveffi_kv_compact_async_async(weaveffi_kv_Store* store, weaveffi_cancel_token* cancel_token, weaveffi_kv_compact_async_callback callback, void* context);
 /** Legacy single-shot put kept for compatibility */
-__attribute__((deprecated("use put() with explicit kind")))
-bool weaveffi_kv_legacy_put(weaveffi_kv_Store* store, const char* key, const uint8_t* value_ptr, size_t value_len, weaveffi_error* out_err);
+WEAVEFFI_DEPRECATED("use put() with explicit kind")
+WEAVEFFI_API bool weaveffi_kv_legacy_put(weaveffi_kv_Store* store, const char* key, const uint8_t* value_ptr, size_t value_len, weaveffi_error* out_err);
 
 // Module: kv_stats
 /** Aggregate store statistics */
-weaveffi_kv_stats_Stats* weaveffi_kv_stats_Stats_create(int64_t total_entries, int64_t total_bytes, int64_t expired_entries, weaveffi_error* out_err);
-void weaveffi_kv_stats_Stats_destroy(weaveffi_kv_stats_Stats* ptr);
+WEAVEFFI_API weaveffi_kv_stats_Stats* weaveffi_kv_stats_Stats_create(int64_t total_entries, int64_t total_bytes, int64_t expired_entries, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_stats_Stats_destroy(weaveffi_kv_stats_Stats* ptr);
 /** Number of live entries */
-int64_t weaveffi_kv_stats_Stats_get_total_entries(const weaveffi_kv_stats_Stats* ptr);
+WEAVEFFI_API int64_t weaveffi_kv_stats_Stats_get_total_entries(const weaveffi_kv_stats_Stats* ptr);
 /** Sum of all value byte lengths */
-int64_t weaveffi_kv_stats_Stats_get_total_bytes(const weaveffi_kv_stats_Stats* ptr);
+WEAVEFFI_API int64_t weaveffi_kv_stats_Stats_get_total_bytes(const weaveffi_kv_stats_Stats* ptr);
 /** Number of entries past their TTL but not yet evicted */
-int64_t weaveffi_kv_stats_Stats_get_expired_entries(const weaveffi_kv_stats_Stats* ptr);
+WEAVEFFI_API int64_t weaveffi_kv_stats_Stats_get_expired_entries(const weaveffi_kv_stats_Stats* ptr);
 
 /** Snapshot the current store statistics */
-weaveffi_kv_stats_Stats* weaveffi_kv_stats_get_stats(weaveffi_kv_Store* store, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_kv_stats_Stats* weaveffi_kv_stats_get_stats(weaveffi_kv_Store* store, weaveffi_error* out_err);
 
 
 #ifdef __cplusplus

--- a/crates/weaveffi-cli/tests/snapshots/c_nested_modules__weaveffi_h.snap
+++ b/crates/weaveffi-cli/tests/snapshots/c_nested_modules__weaveffi_h.snap
@@ -12,6 +12,30 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,15 +44,15 @@ typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /*
  * Map convention: Maps are passed as parallel arrays of keys and values.
@@ -47,38 +71,38 @@ typedef struct weaveffi_graphics_shapes_geometry_Detail weaveffi_graphics_shapes
 
 // Module: graphics
 /** Top-level struct that references a struct defined one level deeper. */
-weaveffi_graphics_Canvas* weaveffi_graphics_Canvas_create(int32_t width, const weaveffi_graphics_shapes_Shape* root, weaveffi_error* out_err);
-void weaveffi_graphics_Canvas_destroy(weaveffi_graphics_Canvas* ptr);
-int32_t weaveffi_graphics_Canvas_get_width(const weaveffi_graphics_Canvas* ptr);
+WEAVEFFI_API weaveffi_graphics_Canvas* weaveffi_graphics_Canvas_create(int32_t width, const weaveffi_graphics_shapes_Shape* root, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_graphics_Canvas_destroy(weaveffi_graphics_Canvas* ptr);
+WEAVEFFI_API int32_t weaveffi_graphics_Canvas_get_width(const weaveffi_graphics_Canvas* ptr);
 /** Reference down into a nested module */
-weaveffi_graphics_shapes_Shape* weaveffi_graphics_Canvas_get_root(const weaveffi_graphics_Canvas* ptr);
+WEAVEFFI_API weaveffi_graphics_shapes_Shape* weaveffi_graphics_Canvas_get_root(const weaveffi_graphics_Canvas* ptr);
 
 /** Construct a Canvas. */
-weaveffi_graphics_Canvas* weaveffi_graphics_new_canvas(int32_t width, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_graphics_Canvas* weaveffi_graphics_new_canvas(int32_t width, weaveffi_error* out_err);
 
 // Module: graphics_shapes
 /** A struct one level deep that references both an ancestor enum and a deeper struct. */
-weaveffi_graphics_shapes_Shape* weaveffi_graphics_shapes_Shape_create(int32_t sides, weaveffi_graphics_Unit unit, const weaveffi_graphics_shapes_geometry_Detail* detail, weaveffi_error* out_err);
-void weaveffi_graphics_shapes_Shape_destroy(weaveffi_graphics_shapes_Shape* ptr);
-int32_t weaveffi_graphics_shapes_Shape_get_sides(const weaveffi_graphics_shapes_Shape* ptr);
+WEAVEFFI_API weaveffi_graphics_shapes_Shape* weaveffi_graphics_shapes_Shape_create(int32_t sides, weaveffi_graphics_Unit unit, const weaveffi_graphics_shapes_geometry_Detail* detail, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_graphics_shapes_Shape_destroy(weaveffi_graphics_shapes_Shape* ptr);
+WEAVEFFI_API int32_t weaveffi_graphics_shapes_Shape_get_sides(const weaveffi_graphics_shapes_Shape* ptr);
 /** Reference up to the parent module's enum */
-weaveffi_graphics_Unit weaveffi_graphics_shapes_Shape_get_unit(const weaveffi_graphics_shapes_Shape* ptr);
+WEAVEFFI_API weaveffi_graphics_Unit weaveffi_graphics_shapes_Shape_get_unit(const weaveffi_graphics_shapes_Shape* ptr);
 /** Reference down into a deeper module */
-weaveffi_graphics_shapes_geometry_Detail* weaveffi_graphics_shapes_Shape_get_detail(const weaveffi_graphics_shapes_Shape* ptr);
+WEAVEFFI_API weaveffi_graphics_shapes_geometry_Detail* weaveffi_graphics_shapes_Shape_get_detail(const weaveffi_graphics_shapes_Shape* ptr);
 
 /** Construct a Shape. */
-weaveffi_graphics_shapes_Shape* weaveffi_graphics_shapes_make_shape(int32_t sides, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_graphics_shapes_Shape* weaveffi_graphics_shapes_make_shape(int32_t sides, weaveffi_error* out_err);
 /** Nested function returning a struct owned by an ancestor module. */
-weaveffi_graphics_Canvas* weaveffi_graphics_shapes_describe(weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_graphics_Canvas* weaveffi_graphics_shapes_describe(weaveffi_error* out_err);
 
 // Module: graphics_shapes_geometry
 /** A struct two levels deep. */
-weaveffi_graphics_shapes_geometry_Detail* weaveffi_graphics_shapes_geometry_Detail_create(double area, weaveffi_error* out_err);
-void weaveffi_graphics_shapes_geometry_Detail_destroy(weaveffi_graphics_shapes_geometry_Detail* ptr);
-double weaveffi_graphics_shapes_geometry_Detail_get_area(const weaveffi_graphics_shapes_geometry_Detail* ptr);
+WEAVEFFI_API weaveffi_graphics_shapes_geometry_Detail* weaveffi_graphics_shapes_geometry_Detail_create(double area, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_graphics_shapes_geometry_Detail_destroy(weaveffi_graphics_shapes_geometry_Detail* ptr);
+WEAVEFFI_API double weaveffi_graphics_shapes_geometry_Detail_get_area(const weaveffi_graphics_shapes_geometry_Detail* ptr);
 
 /** Deeper function taking an ancestor-module struct. */
-weaveffi_graphics_shapes_geometry_Detail* weaveffi_graphics_shapes_geometry_compute(const weaveffi_graphics_shapes_Shape* shape, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_graphics_shapes_geometry_Detail* weaveffi_graphics_shapes_geometry_compute(const weaveffi_graphics_shapes_Shape* shape, weaveffi_error* out_err);
 
 
 #ifdef __cplusplus

--- a/crates/weaveffi-cli/tests/snapshots/c_shapes__weaveffi_h.snap
+++ b/crates/weaveffi-cli/tests/snapshots/c_shapes__weaveffi_h.snap
@@ -12,6 +12,30 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,15 +44,15 @@ typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /*
  * Map convention: Maps are passed as parallel arrays of keys and values.
@@ -59,50 +83,50 @@ typedef struct weaveffi_shapes_Numerics weaveffi_shapes_Numerics;
 
 // Module: shapes
 /** An algebraic shape (sum type with associated data) */
-int32_t weaveffi_shapes_Shape_tag(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API int32_t weaveffi_shapes_Shape_tag(const weaveffi_shapes_Shape* self);
 /** The empty shape (a unit variant) */
-weaveffi_shapes_Shape* weaveffi_shapes_Shape_Empty_new(weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_shapes_Shape* weaveffi_shapes_Shape_Empty_new(weaveffi_error* out_err);
 /** A circle with a radius */
-weaveffi_shapes_Shape* weaveffi_shapes_Shape_Circle_new(double radius, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_shapes_Shape* weaveffi_shapes_Shape_Circle_new(double radius, weaveffi_error* out_err);
 /** Radius in points */
-double weaveffi_shapes_Shape_Circle_get_radius(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API double weaveffi_shapes_Shape_Circle_get_radius(const weaveffi_shapes_Shape* self);
 /** An axis-aligned rectangle */
-weaveffi_shapes_Shape* weaveffi_shapes_Shape_Rectangle_new(float width, float height, weaveffi_error* out_err);
-float weaveffi_shapes_Shape_Rectangle_get_width(const weaveffi_shapes_Shape* self);
-float weaveffi_shapes_Shape_Rectangle_get_height(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API weaveffi_shapes_Shape* weaveffi_shapes_Shape_Rectangle_new(float width, float height, weaveffi_error* out_err);
+WEAVEFFI_API float weaveffi_shapes_Shape_Rectangle_get_width(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API float weaveffi_shapes_Shape_Rectangle_get_height(const weaveffi_shapes_Shape* self);
 /** An integer-bounded shape (exercises narrow + wide ints) */
-weaveffi_shapes_Shape* weaveffi_shapes_Shape_Bounded_new(int16_t min, int16_t max, uint64_t weight, weaveffi_error* out_err);
-int16_t weaveffi_shapes_Shape_Bounded_get_min(const weaveffi_shapes_Shape* self);
-int16_t weaveffi_shapes_Shape_Bounded_get_max(const weaveffi_shapes_Shape* self);
-uint64_t weaveffi_shapes_Shape_Bounded_get_weight(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API weaveffi_shapes_Shape* weaveffi_shapes_Shape_Bounded_new(int16_t min, int16_t max, uint64_t weight, weaveffi_error* out_err);
+WEAVEFFI_API int16_t weaveffi_shapes_Shape_Bounded_get_min(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API int16_t weaveffi_shapes_Shape_Bounded_get_max(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API uint64_t weaveffi_shapes_Shape_Bounded_get_weight(const weaveffi_shapes_Shape* self);
 /** A labeled shape with a small count */
-weaveffi_shapes_Shape* weaveffi_shapes_Shape_Labeled_new(const char* label, uint8_t count, weaveffi_error* out_err);
-const char* weaveffi_shapes_Shape_Labeled_get_label(const weaveffi_shapes_Shape* self);
-uint8_t weaveffi_shapes_Shape_Labeled_get_count(const weaveffi_shapes_Shape* self);
-void weaveffi_shapes_Shape_destroy(weaveffi_shapes_Shape* self);
+WEAVEFFI_API weaveffi_shapes_Shape* weaveffi_shapes_Shape_Labeled_new(const char* label, uint8_t count, weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_shapes_Shape_Labeled_get_label(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API uint8_t weaveffi_shapes_Shape_Labeled_get_count(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API void weaveffi_shapes_Shape_destroy(weaveffi_shapes_Shape* self);
 
 /** One field per supported numeric primitive */
-weaveffi_shapes_Numerics* weaveffi_shapes_Numerics_create(int8_t a, int16_t b, int32_t c, int64_t d, uint8_t e, uint16_t f, uint32_t g, uint64_t h, float i, double j, weaveffi_error* out_err);
-void weaveffi_shapes_Numerics_destroy(weaveffi_shapes_Numerics* ptr);
-int8_t weaveffi_shapes_Numerics_get_a(const weaveffi_shapes_Numerics* ptr);
-int16_t weaveffi_shapes_Numerics_get_b(const weaveffi_shapes_Numerics* ptr);
-int32_t weaveffi_shapes_Numerics_get_c(const weaveffi_shapes_Numerics* ptr);
-int64_t weaveffi_shapes_Numerics_get_d(const weaveffi_shapes_Numerics* ptr);
-uint8_t weaveffi_shapes_Numerics_get_e(const weaveffi_shapes_Numerics* ptr);
-uint16_t weaveffi_shapes_Numerics_get_f(const weaveffi_shapes_Numerics* ptr);
-uint32_t weaveffi_shapes_Numerics_get_g(const weaveffi_shapes_Numerics* ptr);
-uint64_t weaveffi_shapes_Numerics_get_h(const weaveffi_shapes_Numerics* ptr);
-float weaveffi_shapes_Numerics_get_i(const weaveffi_shapes_Numerics* ptr);
-double weaveffi_shapes_Numerics_get_j(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API weaveffi_shapes_Numerics* weaveffi_shapes_Numerics_create(int8_t a, int16_t b, int32_t c, int64_t d, uint8_t e, uint16_t f, uint32_t g, uint64_t h, float i, double j, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_shapes_Numerics_destroy(weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API int8_t weaveffi_shapes_Numerics_get_a(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API int16_t weaveffi_shapes_Numerics_get_b(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API int32_t weaveffi_shapes_Numerics_get_c(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API int64_t weaveffi_shapes_Numerics_get_d(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API uint8_t weaveffi_shapes_Numerics_get_e(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API uint16_t weaveffi_shapes_Numerics_get_f(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API uint32_t weaveffi_shapes_Numerics_get_g(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API uint64_t weaveffi_shapes_Numerics_get_h(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API float weaveffi_shapes_Numerics_get_i(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API double weaveffi_shapes_Numerics_get_j(const weaveffi_shapes_Numerics* ptr);
 
 /** Render a shape to a string */
-const char* weaveffi_shapes_describe(const weaveffi_shapes_Shape* shape, weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_shapes_describe(const weaveffi_shapes_Shape* shape, weaveffi_error* out_err);
 /** Scale a shape by a factor, returning a new shape */
-weaveffi_shapes_Shape* weaveffi_shapes_scale(const weaveffi_shapes_Shape* shape, double factor, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_shapes_Shape* weaveffi_shapes_scale(const weaveffi_shapes_Shape* shape, double factor, weaveffi_error* out_err);
 /** Sum a list of bytes into a wide integer (numerics smoke) */
-uint64_t weaveffi_shapes_sum_bytes(const uint8_t* values, size_t values_len, weaveffi_error* out_err);
+WEAVEFFI_API uint64_t weaveffi_shapes_sum_bytes(const uint8_t* values, size_t values_len, weaveffi_error* out_err);
 /** Build a Numerics struct from every numeric primitive */
-weaveffi_shapes_Numerics* weaveffi_shapes_make_numerics(int8_t a, int16_t b, int32_t c, int64_t d, uint8_t e, uint16_t f, uint32_t g, uint64_t h, float i, double j, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_shapes_Numerics* weaveffi_shapes_make_numerics(int8_t a, int16_t b, int32_t c, int64_t d, uint8_t e, uint16_t f, uint32_t g, uint64_t h, float i, double j, weaveffi_error* out_err);
 
 
 #ifdef __cplusplus

--- a/crates/weaveffi-cli/tests/snapshots/cpp_async_demo__weaveffi_hpp.snap
+++ b/crates/weaveffi-cli/tests/snapshots/cpp_async_demo__weaveffi_hpp.snap
@@ -16,38 +16,62 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <stdexcept>
 #include <future>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 extern "C" {
 
 typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 typedef struct weaveffi_tasks_TaskResult weaveffi_tasks_TaskResult;
 typedef void (*weaveffi_tasks_run_task_callback)(void* context, weaveffi_error* err, weaveffi_tasks_TaskResult* result);
 typedef void (*weaveffi_tasks_run_batch_callback)(void* context, weaveffi_error* err, weaveffi_tasks_TaskResult** result, size_t result_len);
 typedef void (*weaveffi_tasks_run_n_tasks_callback)(void* context, weaveffi_error* err, int32_t result);
 
-weaveffi_tasks_TaskResult* weaveffi_tasks_TaskResult_create(int64_t id, const char* value, bool success, weaveffi_error* out_err);
-void weaveffi_tasks_TaskResult_destroy(weaveffi_tasks_TaskResult* ptr);
-int64_t weaveffi_tasks_TaskResult_get_id(const weaveffi_tasks_TaskResult* ptr);
-const char* weaveffi_tasks_TaskResult_get_value(const weaveffi_tasks_TaskResult* ptr);
-bool weaveffi_tasks_TaskResult_get_success(const weaveffi_tasks_TaskResult* ptr);
+WEAVEFFI_API weaveffi_tasks_TaskResult* weaveffi_tasks_TaskResult_create(int64_t id, const char* value, bool success, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_tasks_TaskResult_destroy(weaveffi_tasks_TaskResult* ptr);
+WEAVEFFI_API int64_t weaveffi_tasks_TaskResult_get_id(const weaveffi_tasks_TaskResult* ptr);
+WEAVEFFI_API const char* weaveffi_tasks_TaskResult_get_value(const weaveffi_tasks_TaskResult* ptr);
+WEAVEFFI_API bool weaveffi_tasks_TaskResult_get_success(const weaveffi_tasks_TaskResult* ptr);
 
-void weaveffi_tasks_run_task_async(const char* name, weaveffi_tasks_run_task_callback callback, void* context);
-void weaveffi_tasks_run_batch_async(const char* const* names, size_t names_len, weaveffi_tasks_run_batch_callback callback, void* context);
-bool weaveffi_tasks_cancel_task(int64_t id, weaveffi_error* out_err);
-void weaveffi_tasks_run_n_tasks_async(int32_t n, weaveffi_tasks_run_n_tasks_callback callback, void* context);
-int64_t weaveffi_tasks_active_callbacks(weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_tasks_run_task_async(const char* name, weaveffi_tasks_run_task_callback callback, void* context);
+WEAVEFFI_API void weaveffi_tasks_run_batch_async(const char* const* names, size_t names_len, weaveffi_tasks_run_batch_callback callback, void* context);
+WEAVEFFI_API bool weaveffi_tasks_cancel_task(int64_t id, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_tasks_run_n_tasks_async(int32_t n, weaveffi_tasks_run_n_tasks_callback callback, void* context);
+WEAVEFFI_API int64_t weaveffi_tasks_active_callbacks(weaveffi_error* out_err);
 
 } // extern "C"
 

--- a/crates/weaveffi-cli/tests/snapshots/cpp_calculator__weaveffi_hpp.snap
+++ b/crates/weaveffi-cli/tests/snapshots/cpp_calculator__weaveffi_hpp.snap
@@ -15,31 +15,55 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <memory>
 #include <stdexcept>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 extern "C" {
 
 typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 
 /** Add two integers */
-int32_t weaveffi_calculator_add(int32_t a, int32_t b, weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_calculator_add(int32_t a, int32_t b, weaveffi_error* out_err);
 /** Multiply two integers */
-int32_t weaveffi_calculator_mul(int32_t a, int32_t b, weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_calculator_mul(int32_t a, int32_t b, weaveffi_error* out_err);
 /** Divide two integers */
-int32_t weaveffi_calculator_div(int32_t a, int32_t b, weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_calculator_div(int32_t a, int32_t b, weaveffi_error* out_err);
 /** Echo a string back */
-const char* weaveffi_calculator_echo(const char* s, weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_calculator_echo(const char* s, weaveffi_error* out_err);
 
 } // extern "C"
 

--- a/crates/weaveffi-cli/tests/snapshots/cpp_contacts__weaveffi_hpp.snap
+++ b/crates/weaveffi-cli/tests/snapshots/cpp_contacts__weaveffi_hpp.snap
@@ -15,38 +15,62 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <memory>
 #include <stdexcept>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 extern "C" {
 
 typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 typedef enum { weaveffi_contacts_ContactType_Personal = 0, weaveffi_contacts_ContactType_Work = 1, weaveffi_contacts_ContactType_Other = 2 } weaveffi_contacts_ContactType;
 typedef struct weaveffi_contacts_Contact weaveffi_contacts_Contact;
 
-weaveffi_contacts_Contact* weaveffi_contacts_Contact_create(int64_t id, const char* first_name, const char* last_name, const char* email, weaveffi_contacts_ContactType contact_type, weaveffi_error* out_err);
-void weaveffi_contacts_Contact_destroy(weaveffi_contacts_Contact* ptr);
-int64_t weaveffi_contacts_Contact_get_id(const weaveffi_contacts_Contact* ptr);
-const char* weaveffi_contacts_Contact_get_first_name(const weaveffi_contacts_Contact* ptr);
-const char* weaveffi_contacts_Contact_get_last_name(const weaveffi_contacts_Contact* ptr);
-const char* weaveffi_contacts_Contact_get_email(const weaveffi_contacts_Contact* ptr);
-weaveffi_contacts_ContactType weaveffi_contacts_Contact_get_contact_type(const weaveffi_contacts_Contact* ptr);
+WEAVEFFI_API weaveffi_contacts_Contact* weaveffi_contacts_Contact_create(int64_t id, const char* first_name, const char* last_name, const char* email, weaveffi_contacts_ContactType contact_type, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_contacts_Contact_destroy(weaveffi_contacts_Contact* ptr);
+WEAVEFFI_API int64_t weaveffi_contacts_Contact_get_id(const weaveffi_contacts_Contact* ptr);
+WEAVEFFI_API const char* weaveffi_contacts_Contact_get_first_name(const weaveffi_contacts_Contact* ptr);
+WEAVEFFI_API const char* weaveffi_contacts_Contact_get_last_name(const weaveffi_contacts_Contact* ptr);
+WEAVEFFI_API const char* weaveffi_contacts_Contact_get_email(const weaveffi_contacts_Contact* ptr);
+WEAVEFFI_API weaveffi_contacts_ContactType weaveffi_contacts_Contact_get_contact_type(const weaveffi_contacts_Contact* ptr);
 
-weaveffi_handle_t weaveffi_contacts_create_contact(const char* first_name, const char* last_name, const char* email, weaveffi_contacts_ContactType contact_type, weaveffi_error* out_err);
-weaveffi_contacts_Contact* weaveffi_contacts_get_contact(weaveffi_handle_t id, weaveffi_error* out_err);
-weaveffi_contacts_Contact** weaveffi_contacts_list_contacts(size_t* out_len, weaveffi_error* out_err);
-bool weaveffi_contacts_delete_contact(weaveffi_handle_t id, weaveffi_error* out_err);
-int32_t weaveffi_contacts_count_contacts(weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_handle_t weaveffi_contacts_create_contact(const char* first_name, const char* last_name, const char* email, weaveffi_contacts_ContactType contact_type, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_contacts_Contact* weaveffi_contacts_get_contact(weaveffi_handle_t id, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_contacts_Contact** weaveffi_contacts_list_contacts(size_t* out_len, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_contacts_delete_contact(weaveffi_handle_t id, weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_contacts_count_contacts(weaveffi_error* out_err);
 
 } // extern "C"
 

--- a/crates/weaveffi-cli/tests/snapshots/cpp_docs_everywhere__weaveffi_hpp.snap
+++ b/crates/weaveffi-cli/tests/snapshots/cpp_docs_everywhere__weaveffi_hpp.snap
@@ -18,21 +18,45 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <functional>
 #include <mutex>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 extern "C" {
 
 typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /**
  * Lifecycle status of a document.
@@ -58,44 +82,44 @@ typedef void (*weaveffi_docs_publish_async_callback)(void* context, weaveffi_err
  *
  * Documents are persisted to disk and exposed via the public API.
  */
-weaveffi_docs_Document* weaveffi_docs_Document_create(int64_t id, const char* title, weaveffi_docs_Status status, const char* const* tags, size_t tags_len, weaveffi_error* out_err);
-void weaveffi_docs_Document_destroy(weaveffi_docs_Document* ptr);
+WEAVEFFI_API weaveffi_docs_Document* weaveffi_docs_Document_create(int64_t id, const char* title, weaveffi_docs_Status status, const char* const* tags, size_t tags_len, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_docs_Document_destroy(weaveffi_docs_Document* ptr);
 /** Stable opaque identifier */
-int64_t weaveffi_docs_Document_get_id(const weaveffi_docs_Document* ptr);
+WEAVEFFI_API int64_t weaveffi_docs_Document_get_id(const weaveffi_docs_Document* ptr);
 /** Human-readable title shown in lists */
-const char* weaveffi_docs_Document_get_title(const weaveffi_docs_Document* ptr);
+WEAVEFFI_API const char* weaveffi_docs_Document_get_title(const weaveffi_docs_Document* ptr);
 /** Current lifecycle status */
-weaveffi_docs_Status weaveffi_docs_Document_get_status(const weaveffi_docs_Document* ptr);
+WEAVEFFI_API weaveffi_docs_Status weaveffi_docs_Document_get_status(const weaveffi_docs_Document* ptr);
 /** Free-form tags for grouping */
-const char** weaveffi_docs_Document_get_tags(const weaveffi_docs_Document* ptr, size_t* out_len);
+WEAVEFFI_API const char** weaveffi_docs_Document_get_tags(const weaveffi_docs_Document* ptr, size_t* out_len);
 
-weaveffi_docs_DocumentBuilder* weaveffi_docs_Document_Builder_new(void);
+WEAVEFFI_API weaveffi_docs_DocumentBuilder* weaveffi_docs_Document_Builder_new(void);
 /** Stable opaque identifier */
-void weaveffi_docs_Document_Builder_set_id(weaveffi_docs_DocumentBuilder* builder, int64_t id);
+WEAVEFFI_API void weaveffi_docs_Document_Builder_set_id(weaveffi_docs_DocumentBuilder* builder, int64_t id);
 /** Human-readable title shown in lists */
-void weaveffi_docs_Document_Builder_set_title(weaveffi_docs_DocumentBuilder* builder, const char* title);
+WEAVEFFI_API void weaveffi_docs_Document_Builder_set_title(weaveffi_docs_DocumentBuilder* builder, const char* title);
 /** Current lifecycle status */
-void weaveffi_docs_Document_Builder_set_status(weaveffi_docs_DocumentBuilder* builder, weaveffi_docs_Status status);
+WEAVEFFI_API void weaveffi_docs_Document_Builder_set_status(weaveffi_docs_DocumentBuilder* builder, weaveffi_docs_Status status);
 /** Free-form tags for grouping */
-void weaveffi_docs_Document_Builder_set_tags(weaveffi_docs_DocumentBuilder* builder, const char* const* tags, size_t tags_len);
-weaveffi_docs_Document* weaveffi_docs_Document_Builder_build(weaveffi_docs_DocumentBuilder* builder, weaveffi_error* out_err);
-void weaveffi_docs_Document_Builder_destroy(weaveffi_docs_DocumentBuilder* builder);
+WEAVEFFI_API void weaveffi_docs_Document_Builder_set_tags(weaveffi_docs_DocumentBuilder* builder, const char* const* tags, size_t tags_len);
+WEAVEFFI_API weaveffi_docs_Document* weaveffi_docs_Document_Builder_build(weaveffi_docs_DocumentBuilder* builder, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_docs_Document_Builder_destroy(weaveffi_docs_DocumentBuilder* builder);
 
 /** Subscribe to document-saved notifications */
-uint64_t weaveffi_docs_register_saved_listener(weaveffi_docs_OnSaved_fn callback, void* context);
+WEAVEFFI_API uint64_t weaveffi_docs_register_saved_listener(weaveffi_docs_OnSaved_fn callback, void* context);
 /** Subscribe to document-saved notifications */
-void weaveffi_docs_unregister_saved_listener(uint64_t id);
+WEAVEFFI_API void weaveffi_docs_unregister_saved_listener(uint64_t id);
 /**
  * Create a brand new document.
  *
  * The document starts in `Draft` status; callers must publish
  * it explicitly to make it visible.
  */
-weaveffi_docs_Document* weaveffi_docs_create_document(const char* title, const char* const* tags, size_t tags_len, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_docs_Document* weaveffi_docs_create_document(const char* title, const char* const* tags, size_t tags_len, weaveffi_error* out_err);
 /** Look up a document by identifier */
-weaveffi_docs_Document* weaveffi_docs_get_document(int64_t id, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_docs_Document* weaveffi_docs_get_document(int64_t id, weaveffi_error* out_err);
 /** Publish a document in the background */
-void weaveffi_docs_publish_async_async(int64_t id, weaveffi_docs_publish_async_callback callback, void* context);
+WEAVEFFI_API void weaveffi_docs_publish_async_async(int64_t id, weaveffi_docs_publish_async_callback callback, void* context);
 
 } // extern "C"
 

--- a/crates/weaveffi-cli/tests/snapshots/cpp_events__weaveffi_hpp.snap
+++ b/crates/weaveffi-cli/tests/snapshots/cpp_events__weaveffi_hpp.snap
@@ -17,33 +17,57 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <functional>
 #include <mutex>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 extern "C" {
 
 typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 typedef struct weaveffi_events_GetMessagesIterator weaveffi_events_GetMessagesIterator;
 typedef void (*weaveffi_events_OnMessage_fn)(const char* message, void* context);
 
-uint64_t weaveffi_events_register_message_listener(weaveffi_events_OnMessage_fn callback, void* context);
-void weaveffi_events_unregister_message_listener(uint64_t id);
+WEAVEFFI_API uint64_t weaveffi_events_register_message_listener(weaveffi_events_OnMessage_fn callback, void* context);
+WEAVEFFI_API void weaveffi_events_unregister_message_listener(uint64_t id);
 /** Send a message, triggering the OnMessage callback */
-void weaveffi_events_send_message(const char* text, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_events_send_message(const char* text, weaveffi_error* out_err);
 /** Return an iterator over all sent messages */
-weaveffi_events_GetMessagesIterator* weaveffi_events_get_messages(weaveffi_error* out_err);
-int32_t weaveffi_events_GetMessagesIterator_next(weaveffi_events_GetMessagesIterator* iter, const char** out_item, weaveffi_error* out_err);
-void weaveffi_events_GetMessagesIterator_destroy(weaveffi_events_GetMessagesIterator* iter);
+WEAVEFFI_API weaveffi_events_GetMessagesIterator* weaveffi_events_get_messages(weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_events_GetMessagesIterator_next(weaveffi_events_GetMessagesIterator* iter, const char** out_item, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_events_GetMessagesIterator_destroy(weaveffi_events_GetMessagesIterator* iter);
 
 } // extern "C"
 

--- a/crates/weaveffi-cli/tests/snapshots/cpp_inventory__weaveffi_hpp.snap
+++ b/crates/weaveffi-cli/tests/snapshots/cpp_inventory__weaveffi_hpp.snap
@@ -15,59 +15,83 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <memory>
 #include <stdexcept>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 extern "C" {
 
 typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 typedef enum { weaveffi_products_Category_Electronics = 0, weaveffi_products_Category_Clothing = 1, weaveffi_products_Category_Food = 2, weaveffi_products_Category_Books = 3 } weaveffi_products_Category;
 typedef struct weaveffi_products_Product weaveffi_products_Product;
 typedef struct weaveffi_orders_OrderItem weaveffi_orders_OrderItem;
 typedef struct weaveffi_orders_Order weaveffi_orders_Order;
 
-weaveffi_products_Product* weaveffi_products_Product_create(int64_t id, const char* name, const char* description, double price, weaveffi_products_Category category, const char* const* tags, size_t tags_len, weaveffi_error* out_err);
-void weaveffi_products_Product_destroy(weaveffi_products_Product* ptr);
-int64_t weaveffi_products_Product_get_id(const weaveffi_products_Product* ptr);
-const char* weaveffi_products_Product_get_name(const weaveffi_products_Product* ptr);
-const char* weaveffi_products_Product_get_description(const weaveffi_products_Product* ptr);
-double weaveffi_products_Product_get_price(const weaveffi_products_Product* ptr);
-weaveffi_products_Category weaveffi_products_Product_get_category(const weaveffi_products_Product* ptr);
-const char** weaveffi_products_Product_get_tags(const weaveffi_products_Product* ptr, size_t* out_len);
+WEAVEFFI_API weaveffi_products_Product* weaveffi_products_Product_create(int64_t id, const char* name, const char* description, double price, weaveffi_products_Category category, const char* const* tags, size_t tags_len, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_products_Product_destroy(weaveffi_products_Product* ptr);
+WEAVEFFI_API int64_t weaveffi_products_Product_get_id(const weaveffi_products_Product* ptr);
+WEAVEFFI_API const char* weaveffi_products_Product_get_name(const weaveffi_products_Product* ptr);
+WEAVEFFI_API const char* weaveffi_products_Product_get_description(const weaveffi_products_Product* ptr);
+WEAVEFFI_API double weaveffi_products_Product_get_price(const weaveffi_products_Product* ptr);
+WEAVEFFI_API weaveffi_products_Category weaveffi_products_Product_get_category(const weaveffi_products_Product* ptr);
+WEAVEFFI_API const char** weaveffi_products_Product_get_tags(const weaveffi_products_Product* ptr, size_t* out_len);
 
-weaveffi_handle_t weaveffi_products_create_product(const char* name, double price, weaveffi_products_Category category, weaveffi_error* out_err);
-weaveffi_products_Product* weaveffi_products_get_product(weaveffi_handle_t id, weaveffi_error* out_err);
-weaveffi_products_Product** weaveffi_products_search_products(weaveffi_products_Category category, size_t* out_len, weaveffi_error* out_err);
-bool weaveffi_products_update_price(weaveffi_handle_t id, double price, weaveffi_error* out_err);
-bool weaveffi_products_delete_product(weaveffi_handle_t id, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_handle_t weaveffi_products_create_product(const char* name, double price, weaveffi_products_Category category, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_products_Product* weaveffi_products_get_product(weaveffi_handle_t id, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_products_Product** weaveffi_products_search_products(weaveffi_products_Category category, size_t* out_len, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_products_update_price(weaveffi_handle_t id, double price, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_products_delete_product(weaveffi_handle_t id, weaveffi_error* out_err);
 
-weaveffi_orders_OrderItem* weaveffi_orders_OrderItem_create(int64_t product_id, int32_t quantity, double unit_price, weaveffi_error* out_err);
-void weaveffi_orders_OrderItem_destroy(weaveffi_orders_OrderItem* ptr);
-int64_t weaveffi_orders_OrderItem_get_product_id(const weaveffi_orders_OrderItem* ptr);
-int32_t weaveffi_orders_OrderItem_get_quantity(const weaveffi_orders_OrderItem* ptr);
-double weaveffi_orders_OrderItem_get_unit_price(const weaveffi_orders_OrderItem* ptr);
+WEAVEFFI_API weaveffi_orders_OrderItem* weaveffi_orders_OrderItem_create(int64_t product_id, int32_t quantity, double unit_price, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_orders_OrderItem_destroy(weaveffi_orders_OrderItem* ptr);
+WEAVEFFI_API int64_t weaveffi_orders_OrderItem_get_product_id(const weaveffi_orders_OrderItem* ptr);
+WEAVEFFI_API int32_t weaveffi_orders_OrderItem_get_quantity(const weaveffi_orders_OrderItem* ptr);
+WEAVEFFI_API double weaveffi_orders_OrderItem_get_unit_price(const weaveffi_orders_OrderItem* ptr);
 
-weaveffi_orders_Order* weaveffi_orders_Order_create(int64_t id, weaveffi_orders_OrderItem* const* items, size_t items_len, double total, const char* status, weaveffi_error* out_err);
-void weaveffi_orders_Order_destroy(weaveffi_orders_Order* ptr);
-int64_t weaveffi_orders_Order_get_id(const weaveffi_orders_Order* ptr);
-weaveffi_orders_OrderItem** weaveffi_orders_Order_get_items(const weaveffi_orders_Order* ptr, size_t* out_len);
-double weaveffi_orders_Order_get_total(const weaveffi_orders_Order* ptr);
-const char* weaveffi_orders_Order_get_status(const weaveffi_orders_Order* ptr);
+WEAVEFFI_API weaveffi_orders_Order* weaveffi_orders_Order_create(int64_t id, weaveffi_orders_OrderItem* const* items, size_t items_len, double total, const char* status, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_orders_Order_destroy(weaveffi_orders_Order* ptr);
+WEAVEFFI_API int64_t weaveffi_orders_Order_get_id(const weaveffi_orders_Order* ptr);
+WEAVEFFI_API weaveffi_orders_OrderItem** weaveffi_orders_Order_get_items(const weaveffi_orders_Order* ptr, size_t* out_len);
+WEAVEFFI_API double weaveffi_orders_Order_get_total(const weaveffi_orders_Order* ptr);
+WEAVEFFI_API const char* weaveffi_orders_Order_get_status(const weaveffi_orders_Order* ptr);
 
-weaveffi_handle_t weaveffi_orders_create_order(weaveffi_orders_OrderItem* const* items, size_t items_len, weaveffi_error* out_err);
-weaveffi_orders_Order* weaveffi_orders_get_order(weaveffi_handle_t id, weaveffi_error* out_err);
-bool weaveffi_orders_cancel_order(weaveffi_handle_t id, weaveffi_error* out_err);
-bool weaveffi_orders_add_product_to_order(weaveffi_handle_t order_id, const weaveffi_products_Product* product, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_handle_t weaveffi_orders_create_order(weaveffi_orders_OrderItem* const* items, size_t items_len, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_orders_Order* weaveffi_orders_get_order(weaveffi_handle_t id, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_orders_cancel_order(weaveffi_handle_t id, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_orders_add_product_to_order(weaveffi_handle_t order_id, const weaveffi_products_Product* product, weaveffi_error* out_err);
 
 } // extern "C"
 

--- a/crates/weaveffi-cli/tests/snapshots/cpp_kitchen_sink__weaveffi_hpp.snap
+++ b/crates/weaveffi-cli/tests/snapshots/cpp_kitchen_sink__weaveffi_hpp.snap
@@ -18,21 +18,45 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <functional>
 #include <mutex>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 extern "C" {
 
 typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /** Task priority levels */
 typedef enum {
@@ -53,102 +77,102 @@ typedef void (*weaveffi_kitchen_do_async_callback)(void* context, weaveffi_error
 typedef void (*weaveffi_kitchen_do_cancellable_callback)(void* context, weaveffi_error* err, const char* result);
 
 /** A reusable token referenced across modules */
-weaveffi_shared_Token* weaveffi_shared_Token_create(int64_t id, const char* label, weaveffi_error* out_err);
-void weaveffi_shared_Token_destroy(weaveffi_shared_Token* ptr);
-int64_t weaveffi_shared_Token_get_id(const weaveffi_shared_Token* ptr);
-const char* weaveffi_shared_Token_get_label(const weaveffi_shared_Token* ptr);
+WEAVEFFI_API weaveffi_shared_Token* weaveffi_shared_Token_create(int64_t id, const char* label, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_shared_Token_destroy(weaveffi_shared_Token* ptr);
+WEAVEFFI_API int64_t weaveffi_shared_Token_get_id(const weaveffi_shared_Token* ptr);
+WEAVEFFI_API const char* weaveffi_shared_Token_get_label(const weaveffi_shared_Token* ptr);
 
 /** Trivial cross-module helper */
-const char* weaveffi_shared_ping(weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_shared_ping(weaveffi_error* out_err);
 
 /** Kitchen sink struct exercising every field feature */
-weaveffi_kitchen_Item* weaveffi_kitchen_Item_create(int64_t id, const char* name, int32_t count, bool enabled, double ratio, uint32_t nick, const uint8_t* payload_ptr, size_t payload_len, const char* const* tags, size_t tags_len, const char* const* attrs_keys, const char* const* attrs_values, size_t attrs_len, const int64_t* parent, const weaveffi_shared_Token* token, weaveffi_kitchen_Priority priority, weaveffi_error* out_err);
-void weaveffi_kitchen_Item_destroy(weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API weaveffi_kitchen_Item* weaveffi_kitchen_Item_create(int64_t id, const char* name, int32_t count, bool enabled, double ratio, uint32_t nick, const uint8_t* payload_ptr, size_t payload_len, const char* const* tags, size_t tags_len, const char* const* attrs_keys, const char* const* attrs_values, size_t attrs_len, const int64_t* parent, const weaveffi_shared_Token* token, weaveffi_kitchen_Priority priority, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kitchen_Item_destroy(weaveffi_kitchen_Item* ptr);
 /** Stable identifier */
-int64_t weaveffi_kitchen_Item_get_id(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API int64_t weaveffi_kitchen_Item_get_id(const weaveffi_kitchen_Item* ptr);
 /** Display name */
-const char* weaveffi_kitchen_Item_get_name(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API const char* weaveffi_kitchen_Item_get_name(const weaveffi_kitchen_Item* ptr);
 /** Initial count */
-int32_t weaveffi_kitchen_Item_get_count(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API int32_t weaveffi_kitchen_Item_get_count(const weaveffi_kitchen_Item* ptr);
 /** Whether the item is enabled */
-bool weaveffi_kitchen_Item_get_enabled(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API bool weaveffi_kitchen_Item_get_enabled(const weaveffi_kitchen_Item* ptr);
 /** Scaling ratio */
-double weaveffi_kitchen_Item_get_ratio(const weaveffi_kitchen_Item* ptr);
-uint32_t weaveffi_kitchen_Item_get_nick(const weaveffi_kitchen_Item* ptr);
-const uint8_t* weaveffi_kitchen_Item_get_payload(const weaveffi_kitchen_Item* ptr, size_t* out_len);
-const char** weaveffi_kitchen_Item_get_tags(const weaveffi_kitchen_Item* ptr, size_t* out_len);
-void weaveffi_kitchen_Item_get_attrs(const weaveffi_kitchen_Item* ptr, const char*** out_keys, const char*** out_values, size_t* out_len);
-int64_t* weaveffi_kitchen_Item_get_parent(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API double weaveffi_kitchen_Item_get_ratio(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API uint32_t weaveffi_kitchen_Item_get_nick(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API const uint8_t* weaveffi_kitchen_Item_get_payload(const weaveffi_kitchen_Item* ptr, size_t* out_len);
+WEAVEFFI_API const char** weaveffi_kitchen_Item_get_tags(const weaveffi_kitchen_Item* ptr, size_t* out_len);
+WEAVEFFI_API void weaveffi_kitchen_Item_get_attrs(const weaveffi_kitchen_Item* ptr, const char*** out_keys, const char*** out_values, size_t* out_len);
+WEAVEFFI_API int64_t* weaveffi_kitchen_Item_get_parent(const weaveffi_kitchen_Item* ptr);
 /** Cross-module struct reference */
-weaveffi_shared_Token* weaveffi_kitchen_Item_get_token(const weaveffi_kitchen_Item* ptr);
-weaveffi_kitchen_Priority weaveffi_kitchen_Item_get_priority(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API weaveffi_shared_Token* weaveffi_kitchen_Item_get_token(const weaveffi_kitchen_Item* ptr);
+WEAVEFFI_API weaveffi_kitchen_Priority weaveffi_kitchen_Item_get_priority(const weaveffi_kitchen_Item* ptr);
 
-weaveffi_kitchen_ItemBuilder* weaveffi_kitchen_Item_Builder_new(void);
+WEAVEFFI_API weaveffi_kitchen_ItemBuilder* weaveffi_kitchen_Item_Builder_new(void);
 /** Stable identifier */
-void weaveffi_kitchen_Item_Builder_set_id(weaveffi_kitchen_ItemBuilder* builder, int64_t id);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_id(weaveffi_kitchen_ItemBuilder* builder, int64_t id);
 /** Display name */
-void weaveffi_kitchen_Item_Builder_set_name(weaveffi_kitchen_ItemBuilder* builder, const char* name);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_name(weaveffi_kitchen_ItemBuilder* builder, const char* name);
 /** Initial count */
-void weaveffi_kitchen_Item_Builder_set_count(weaveffi_kitchen_ItemBuilder* builder, int32_t count);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_count(weaveffi_kitchen_ItemBuilder* builder, int32_t count);
 /** Whether the item is enabled */
-void weaveffi_kitchen_Item_Builder_set_enabled(weaveffi_kitchen_ItemBuilder* builder, bool enabled);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_enabled(weaveffi_kitchen_ItemBuilder* builder, bool enabled);
 /** Scaling ratio */
-void weaveffi_kitchen_Item_Builder_set_ratio(weaveffi_kitchen_ItemBuilder* builder, double ratio);
-void weaveffi_kitchen_Item_Builder_set_nick(weaveffi_kitchen_ItemBuilder* builder, uint32_t nick);
-void weaveffi_kitchen_Item_Builder_set_payload(weaveffi_kitchen_ItemBuilder* builder, const uint8_t* payload_ptr, size_t payload_len);
-void weaveffi_kitchen_Item_Builder_set_tags(weaveffi_kitchen_ItemBuilder* builder, const char* const* tags, size_t tags_len);
-void weaveffi_kitchen_Item_Builder_set_attrs(weaveffi_kitchen_ItemBuilder* builder, const char* const* attrs_keys, const char* const* attrs_values, size_t attrs_len);
-void weaveffi_kitchen_Item_Builder_set_parent(weaveffi_kitchen_ItemBuilder* builder, const int64_t* parent);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_ratio(weaveffi_kitchen_ItemBuilder* builder, double ratio);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_nick(weaveffi_kitchen_ItemBuilder* builder, uint32_t nick);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_payload(weaveffi_kitchen_ItemBuilder* builder, const uint8_t* payload_ptr, size_t payload_len);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_tags(weaveffi_kitchen_ItemBuilder* builder, const char* const* tags, size_t tags_len);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_attrs(weaveffi_kitchen_ItemBuilder* builder, const char* const* attrs_keys, const char* const* attrs_values, size_t attrs_len);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_parent(weaveffi_kitchen_ItemBuilder* builder, const int64_t* parent);
 /** Cross-module struct reference */
-void weaveffi_kitchen_Item_Builder_set_token(weaveffi_kitchen_ItemBuilder* builder, const weaveffi_shared_Token* token);
-void weaveffi_kitchen_Item_Builder_set_priority(weaveffi_kitchen_ItemBuilder* builder, weaveffi_kitchen_Priority priority);
-weaveffi_kitchen_Item* weaveffi_kitchen_Item_Builder_build(weaveffi_kitchen_ItemBuilder* builder, weaveffi_error* out_err);
-void weaveffi_kitchen_Item_Builder_destroy(weaveffi_kitchen_ItemBuilder* builder);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_token(weaveffi_kitchen_ItemBuilder* builder, const weaveffi_shared_Token* token);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_set_priority(weaveffi_kitchen_ItemBuilder* builder, weaveffi_kitchen_Priority priority);
+WEAVEFFI_API weaveffi_kitchen_Item* weaveffi_kitchen_Item_Builder_build(weaveffi_kitchen_ItemBuilder* builder, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kitchen_Item_Builder_destroy(weaveffi_kitchen_ItemBuilder* builder);
 
 /** Subscribe to OnReady events */
-uint64_t weaveffi_kitchen_register_ready_listener(weaveffi_kitchen_OnReady_fn callback, void* context);
+WEAVEFFI_API uint64_t weaveffi_kitchen_register_ready_listener(weaveffi_kitchen_OnReady_fn callback, void* context);
 /** Subscribe to OnReady events */
-void weaveffi_kitchen_unregister_ready_listener(uint64_t id);
+WEAVEFFI_API void weaveffi_kitchen_unregister_ready_listener(uint64_t id);
 /** Identity for bool */
-bool weaveffi_kitchen_bool_id(bool x, weaveffi_error* out_err);
-int32_t weaveffi_kitchen_i32_id(int32_t x, weaveffi_error* out_err);
-uint32_t weaveffi_kitchen_u32_id(uint32_t x, weaveffi_error* out_err);
-int64_t weaveffi_kitchen_i64_id(int64_t x, weaveffi_error* out_err);
-double weaveffi_kitchen_f64_id(double x, weaveffi_error* out_err);
-const char* weaveffi_kitchen_echo_string(const char* s, weaveffi_error* out_err);
-const uint8_t* weaveffi_kitchen_echo_bytes(const uint8_t* b_ptr, size_t b_len, size_t* out_len, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_kitchen_bool_id(bool x, weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_kitchen_i32_id(int32_t x, weaveffi_error* out_err);
+WEAVEFFI_API uint32_t weaveffi_kitchen_u32_id(uint32_t x, weaveffi_error* out_err);
+WEAVEFFI_API int64_t weaveffi_kitchen_i64_id(int64_t x, weaveffi_error* out_err);
+WEAVEFFI_API double weaveffi_kitchen_f64_id(double x, weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_kitchen_echo_string(const char* s, weaveffi_error* out_err);
+WEAVEFFI_API const uint8_t* weaveffi_kitchen_echo_bytes(const uint8_t* b_ptr, size_t b_len, size_t* out_len, weaveffi_error* out_err);
 /** Borrowed string parameter */
-const char* weaveffi_kitchen_echo_borrowed_str(const char* s, weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_kitchen_echo_borrowed_str(const char* s, weaveffi_error* out_err);
 /** Borrowed bytes parameter */
-const uint8_t* weaveffi_kitchen_echo_borrowed_bytes(const uint8_t* b_ptr, size_t b_len, size_t* out_len, weaveffi_error* out_err);
+WEAVEFFI_API const uint8_t* weaveffi_kitchen_echo_borrowed_bytes(const uint8_t* b_ptr, size_t b_len, size_t* out_len, weaveffi_error* out_err);
 /** Returns an opaque handle */
-weaveffi_handle_t weaveffi_kitchen_open_handle(weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_handle_t weaveffi_kitchen_open_handle(weaveffi_error* out_err);
 /** Returns a typed handle */
-weaveffi_shared_Token* weaveffi_kitchen_open_typed_handle(weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_shared_Token* weaveffi_kitchen_open_typed_handle(weaveffi_error* out_err);
 /** Optional struct return */
-weaveffi_kitchen_Item* weaveffi_kitchen_maybe_item(int64_t id, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_kitchen_Item* weaveffi_kitchen_maybe_item(int64_t id, weaveffi_error* out_err);
 /** List of structs */
-weaveffi_kitchen_Item** weaveffi_kitchen_list_items(size_t* out_len, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_kitchen_Item** weaveffi_kitchen_list_items(size_t* out_len, weaveffi_error* out_err);
 /** Map return type */
-void weaveffi_kitchen_get_attrs(const char*** out_keys, int32_t** out_values, size_t* out_len, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kitchen_get_attrs(const char*** out_keys, int32_t** out_values, size_t* out_len, weaveffi_error* out_err);
 /** Iterator return type */
-weaveffi_kitchen_StreamItemsIterator* weaveffi_kitchen_stream_items(weaveffi_error* out_err);
-int32_t weaveffi_kitchen_StreamItemsIterator_next(weaveffi_kitchen_StreamItemsIterator* iter, weaveffi_kitchen_Item** out_item, weaveffi_error* out_err);
-void weaveffi_kitchen_StreamItemsIterator_destroy(weaveffi_kitchen_StreamItemsIterator* iter);
+WEAVEFFI_API weaveffi_kitchen_StreamItemsIterator* weaveffi_kitchen_stream_items(weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_kitchen_StreamItemsIterator_next(weaveffi_kitchen_StreamItemsIterator* iter, weaveffi_kitchen_Item** out_item, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kitchen_StreamItemsIterator_destroy(weaveffi_kitchen_StreamItemsIterator* iter);
 /** Returns the shared Token type from another module */
-weaveffi_shared_Token* weaveffi_kitchen_cross_module_token(weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_shared_Token* weaveffi_kitchen_cross_module_token(weaveffi_error* out_err);
 /** Async operation */
-void weaveffi_kitchen_do_async_async(const char* input, weaveffi_kitchen_do_async_callback callback, void* context);
+WEAVEFFI_API void weaveffi_kitchen_do_async_async(const char* input, weaveffi_kitchen_do_async_callback callback, void* context);
 /** Cancellable async operation */
-void weaveffi_kitchen_do_cancellable_async(const char* input, weaveffi_cancel_token* cancel_token, weaveffi_kitchen_do_cancellable_callback callback, void* context);
+WEAVEFFI_API void weaveffi_kitchen_do_cancellable_async(const char* input, weaveffi_cancel_token* cancel_token, weaveffi_kitchen_do_cancellable_callback callback, void* context);
 /** Legacy operation kept for compatibility */
-__attribute__((deprecated("Use new_op instead")))
-int32_t weaveffi_kitchen_legacy_op(weaveffi_error* out_err);
+WEAVEFFI_DEPRECATED("Use new_op instead")
+WEAVEFFI_API int32_t weaveffi_kitchen_legacy_op(weaveffi_error* out_err);
 /** Replacement for legacy_op */
-int32_t weaveffi_kitchen_new_op(weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_kitchen_new_op(weaveffi_error* out_err);
 
 /** Trivial nested-module function */
-const char* weaveffi_kitchen_nested_hello(weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_kitchen_nested_hello(weaveffi_error* out_err);
 
 } // extern "C"
 

--- a/crates/weaveffi-cli/tests/snapshots/cpp_kvstore__weaveffi_hpp.snap
+++ b/crates/weaveffi-cli/tests/snapshots/cpp_kvstore__weaveffi_hpp.snap
@@ -18,21 +18,45 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <functional>
 #include <mutex>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 extern "C" {
 
 typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /** Persistence semantics applied to a stored entry */
 typedef enum {
@@ -53,87 +77,87 @@ typedef void (*weaveffi_kv_OnEvict_fn)(const char* key, void* context);
 typedef void (*weaveffi_kv_compact_async_callback)(void* context, weaveffi_error* err, int64_t result);
 
 /** Opaque key-value store handle target type */
-weaveffi_kv_Store* weaveffi_kv_Store_create(int64_t id, weaveffi_error* out_err);
-void weaveffi_kv_Store_destroy(weaveffi_kv_Store* ptr);
+WEAVEFFI_API weaveffi_kv_Store* weaveffi_kv_Store_create(int64_t id, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_Store_destroy(weaveffi_kv_Store* ptr);
 /** Internal store identifier */
-int64_t weaveffi_kv_Store_get_id(const weaveffi_kv_Store* ptr);
+WEAVEFFI_API int64_t weaveffi_kv_Store_get_id(const weaveffi_kv_Store* ptr);
 
 /** A single key-value entry persisted in the store */
-weaveffi_kv_Entry* weaveffi_kv_Entry_create(int64_t id, const char* key, const uint8_t* value_ptr, size_t value_len, int64_t created_at, const int64_t* expires_at, const char* const* tags, size_t tags_len, const char* const* metadata_keys, const char* const* metadata_values, size_t metadata_len, weaveffi_error* out_err);
-void weaveffi_kv_Entry_destroy(weaveffi_kv_Entry* ptr);
+WEAVEFFI_API weaveffi_kv_Entry* weaveffi_kv_Entry_create(int64_t id, const char* key, const uint8_t* value_ptr, size_t value_len, int64_t created_at, const int64_t* expires_at, const char* const* tags, size_t tags_len, const char* const* metadata_keys, const char* const* metadata_values, size_t metadata_len, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_Entry_destroy(weaveffi_kv_Entry* ptr);
 /** Stable monotonic identifier assigned on insert */
-int64_t weaveffi_kv_Entry_get_id(const weaveffi_kv_Entry* ptr);
+WEAVEFFI_API int64_t weaveffi_kv_Entry_get_id(const weaveffi_kv_Entry* ptr);
 /** UTF-8 lookup key */
-const char* weaveffi_kv_Entry_get_key(const weaveffi_kv_Entry* ptr);
+WEAVEFFI_API const char* weaveffi_kv_Entry_get_key(const weaveffi_kv_Entry* ptr);
 /** Opaque binary payload */
-const uint8_t* weaveffi_kv_Entry_get_value(const weaveffi_kv_Entry* ptr, size_t* out_len);
+WEAVEFFI_API const uint8_t* weaveffi_kv_Entry_get_value(const weaveffi_kv_Entry* ptr, size_t* out_len);
 /** Unix-timestamp seconds when the entry was created */
-int64_t weaveffi_kv_Entry_get_created_at(const weaveffi_kv_Entry* ptr);
+WEAVEFFI_API int64_t weaveffi_kv_Entry_get_created_at(const weaveffi_kv_Entry* ptr);
 /** Optional unix-timestamp seconds at which the entry expires */
-int64_t* weaveffi_kv_Entry_get_expires_at(const weaveffi_kv_Entry* ptr);
+WEAVEFFI_API int64_t* weaveffi_kv_Entry_get_expires_at(const weaveffi_kv_Entry* ptr);
 /** Free-form labels attached to the entry */
-const char** weaveffi_kv_Entry_get_tags(const weaveffi_kv_Entry* ptr, size_t* out_len);
+WEAVEFFI_API const char** weaveffi_kv_Entry_get_tags(const weaveffi_kv_Entry* ptr, size_t* out_len);
 /** Arbitrary string-valued metadata pairs */
-void weaveffi_kv_Entry_get_metadata(const weaveffi_kv_Entry* ptr, const char*** out_keys, const char*** out_values, size_t* out_len);
+WEAVEFFI_API void weaveffi_kv_Entry_get_metadata(const weaveffi_kv_Entry* ptr, const char*** out_keys, const char*** out_values, size_t* out_len);
 
-weaveffi_kv_EntryBuilder* weaveffi_kv_Entry_Builder_new(void);
+WEAVEFFI_API weaveffi_kv_EntryBuilder* weaveffi_kv_Entry_Builder_new(void);
 /** Stable monotonic identifier assigned on insert */
-void weaveffi_kv_Entry_Builder_set_id(weaveffi_kv_EntryBuilder* builder, int64_t id);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_id(weaveffi_kv_EntryBuilder* builder, int64_t id);
 /** UTF-8 lookup key */
-void weaveffi_kv_Entry_Builder_set_key(weaveffi_kv_EntryBuilder* builder, const char* key);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_key(weaveffi_kv_EntryBuilder* builder, const char* key);
 /** Opaque binary payload */
-void weaveffi_kv_Entry_Builder_set_value(weaveffi_kv_EntryBuilder* builder, const uint8_t* value_ptr, size_t value_len);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_value(weaveffi_kv_EntryBuilder* builder, const uint8_t* value_ptr, size_t value_len);
 /** Unix-timestamp seconds when the entry was created */
-void weaveffi_kv_Entry_Builder_set_created_at(weaveffi_kv_EntryBuilder* builder, int64_t created_at);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_created_at(weaveffi_kv_EntryBuilder* builder, int64_t created_at);
 /** Optional unix-timestamp seconds at which the entry expires */
-void weaveffi_kv_Entry_Builder_set_expires_at(weaveffi_kv_EntryBuilder* builder, const int64_t* expires_at);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_expires_at(weaveffi_kv_EntryBuilder* builder, const int64_t* expires_at);
 /** Free-form labels attached to the entry */
-void weaveffi_kv_Entry_Builder_set_tags(weaveffi_kv_EntryBuilder* builder, const char* const* tags, size_t tags_len);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_tags(weaveffi_kv_EntryBuilder* builder, const char* const* tags, size_t tags_len);
 /** Arbitrary string-valued metadata pairs */
-void weaveffi_kv_Entry_Builder_set_metadata(weaveffi_kv_EntryBuilder* builder, const char* const* metadata_keys, const char* const* metadata_values, size_t metadata_len);
-weaveffi_kv_Entry* weaveffi_kv_Entry_Builder_build(weaveffi_kv_EntryBuilder* builder, weaveffi_error* out_err);
-void weaveffi_kv_Entry_Builder_destroy(weaveffi_kv_EntryBuilder* builder);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_set_metadata(weaveffi_kv_EntryBuilder* builder, const char* const* metadata_keys, const char* const* metadata_values, size_t metadata_len);
+WEAVEFFI_API weaveffi_kv_Entry* weaveffi_kv_Entry_Builder_build(weaveffi_kv_EntryBuilder* builder, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_Entry_Builder_destroy(weaveffi_kv_EntryBuilder* builder);
 
 /** Subscribe to per-key eviction notifications */
-uint64_t weaveffi_kv_register_eviction_listener(weaveffi_kv_OnEvict_fn callback, void* context);
+WEAVEFFI_API uint64_t weaveffi_kv_register_eviction_listener(weaveffi_kv_OnEvict_fn callback, void* context);
 /** Subscribe to per-key eviction notifications */
-void weaveffi_kv_unregister_eviction_listener(uint64_t id);
+WEAVEFFI_API void weaveffi_kv_unregister_eviction_listener(uint64_t id);
 /** Open (or create) a store backed by the given filesystem path */
-weaveffi_kv_Store* weaveffi_kv_open_store(const char* path, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_kv_Store* weaveffi_kv_open_store(const char* path, weaveffi_error* out_err);
 /** Close the store and release all in-memory resources */
-void weaveffi_kv_close_store(weaveffi_kv_Store* store, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_close_store(weaveffi_kv_Store* store, weaveffi_error* out_err);
 /** Insert or replace a value, returning true on success */
-bool weaveffi_kv_put(weaveffi_kv_Store* store, const char* key, const uint8_t* value_ptr, size_t value_len, weaveffi_kv_EntryKind kind, const int64_t* ttl_seconds, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_kv_put(weaveffi_kv_Store* store, const char* key, const uint8_t* value_ptr, size_t value_len, weaveffi_kv_EntryKind kind, const int64_t* ttl_seconds, weaveffi_error* out_err);
 /** Look up an entry by key; returns null if missing or expired */
-weaveffi_kv_Entry* weaveffi_kv_get(weaveffi_kv_Store* store, const char* key, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_kv_Entry* weaveffi_kv_get(weaveffi_kv_Store* store, const char* key, weaveffi_error* out_err);
 /** Remove the entry for the given key, returning true if it existed */
-bool weaveffi_kv_delete(weaveffi_kv_Store* store, const char* key, weaveffi_error* out_err);
+WEAVEFFI_API bool weaveffi_kv_delete(weaveffi_kv_Store* store, const char* key, weaveffi_error* out_err);
 /** Stream every key, optionally filtered by a prefix */
-weaveffi_kv_ListKeysIterator* weaveffi_kv_list_keys(weaveffi_kv_Store* store, const char* prefix, weaveffi_error* out_err);
-int32_t weaveffi_kv_ListKeysIterator_next(weaveffi_kv_ListKeysIterator* iter, const char** out_item, weaveffi_error* out_err);
-void weaveffi_kv_ListKeysIterator_destroy(weaveffi_kv_ListKeysIterator* iter);
+WEAVEFFI_API weaveffi_kv_ListKeysIterator* weaveffi_kv_list_keys(weaveffi_kv_Store* store, const char* prefix, weaveffi_error* out_err);
+WEAVEFFI_API int32_t weaveffi_kv_ListKeysIterator_next(weaveffi_kv_ListKeysIterator* iter, const char** out_item, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_ListKeysIterator_destroy(weaveffi_kv_ListKeysIterator* iter);
 /** Return the number of live entries in the store */
-int64_t weaveffi_kv_count(weaveffi_kv_Store* store, weaveffi_error* out_err);
+WEAVEFFI_API int64_t weaveffi_kv_count(weaveffi_kv_Store* store, weaveffi_error* out_err);
 /** Drop every entry from the store */
-void weaveffi_kv_clear(weaveffi_kv_Store* store, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_clear(weaveffi_kv_Store* store, weaveffi_error* out_err);
 /** Reclaim space asynchronously; returns the number of bytes reclaimed */
-void weaveffi_kv_compact_async_async(weaveffi_kv_Store* store, weaveffi_cancel_token* cancel_token, weaveffi_kv_compact_async_callback callback, void* context);
+WEAVEFFI_API void weaveffi_kv_compact_async_async(weaveffi_kv_Store* store, weaveffi_cancel_token* cancel_token, weaveffi_kv_compact_async_callback callback, void* context);
 /** Legacy single-shot put kept for compatibility */
-__attribute__((deprecated("use put() with explicit kind")))
-bool weaveffi_kv_legacy_put(weaveffi_kv_Store* store, const char* key, const uint8_t* value_ptr, size_t value_len, weaveffi_error* out_err);
+WEAVEFFI_DEPRECATED("use put() with explicit kind")
+WEAVEFFI_API bool weaveffi_kv_legacy_put(weaveffi_kv_Store* store, const char* key, const uint8_t* value_ptr, size_t value_len, weaveffi_error* out_err);
 
 /** Aggregate store statistics */
-weaveffi_kv_stats_Stats* weaveffi_kv_stats_Stats_create(int64_t total_entries, int64_t total_bytes, int64_t expired_entries, weaveffi_error* out_err);
-void weaveffi_kv_stats_Stats_destroy(weaveffi_kv_stats_Stats* ptr);
+WEAVEFFI_API weaveffi_kv_stats_Stats* weaveffi_kv_stats_Stats_create(int64_t total_entries, int64_t total_bytes, int64_t expired_entries, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_kv_stats_Stats_destroy(weaveffi_kv_stats_Stats* ptr);
 /** Number of live entries */
-int64_t weaveffi_kv_stats_Stats_get_total_entries(const weaveffi_kv_stats_Stats* ptr);
+WEAVEFFI_API int64_t weaveffi_kv_stats_Stats_get_total_entries(const weaveffi_kv_stats_Stats* ptr);
 /** Sum of all value byte lengths */
-int64_t weaveffi_kv_stats_Stats_get_total_bytes(const weaveffi_kv_stats_Stats* ptr);
+WEAVEFFI_API int64_t weaveffi_kv_stats_Stats_get_total_bytes(const weaveffi_kv_stats_Stats* ptr);
 /** Number of entries past their TTL but not yet evicted */
-int64_t weaveffi_kv_stats_Stats_get_expired_entries(const weaveffi_kv_stats_Stats* ptr);
+WEAVEFFI_API int64_t weaveffi_kv_stats_Stats_get_expired_entries(const weaveffi_kv_stats_Stats* ptr);
 
 /** Snapshot the current store statistics */
-weaveffi_kv_stats_Stats* weaveffi_kv_stats_get_stats(weaveffi_kv_Store* store, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_kv_stats_Stats* weaveffi_kv_stats_get_stats(weaveffi_kv_Store* store, weaveffi_error* out_err);
 
 } // extern "C"
 

--- a/crates/weaveffi-cli/tests/snapshots/cpp_nested_modules__weaveffi_hpp.snap
+++ b/crates/weaveffi-cli/tests/snapshots/cpp_nested_modules__weaveffi_hpp.snap
@@ -15,21 +15,45 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <memory>
 #include <stdexcept>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 extern "C" {
 
 typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /** A measurement unit shared with nested submodules. */
 typedef enum { weaveffi_graphics_Unit_pixels = 0, weaveffi_graphics_Unit_points = 1 } weaveffi_graphics_Unit;
@@ -38,36 +62,36 @@ typedef struct weaveffi_graphics_shapes_Shape weaveffi_graphics_shapes_Shape;
 typedef struct weaveffi_graphics_shapes_geometry_Detail weaveffi_graphics_shapes_geometry_Detail;
 
 /** Top-level struct that references a struct defined one level deeper. */
-weaveffi_graphics_Canvas* weaveffi_graphics_Canvas_create(int32_t width, const weaveffi_graphics_shapes_Shape* root, weaveffi_error* out_err);
-void weaveffi_graphics_Canvas_destroy(weaveffi_graphics_Canvas* ptr);
-int32_t weaveffi_graphics_Canvas_get_width(const weaveffi_graphics_Canvas* ptr);
+WEAVEFFI_API weaveffi_graphics_Canvas* weaveffi_graphics_Canvas_create(int32_t width, const weaveffi_graphics_shapes_Shape* root, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_graphics_Canvas_destroy(weaveffi_graphics_Canvas* ptr);
+WEAVEFFI_API int32_t weaveffi_graphics_Canvas_get_width(const weaveffi_graphics_Canvas* ptr);
 /** Reference down into a nested module */
-weaveffi_graphics_shapes_Shape* weaveffi_graphics_Canvas_get_root(const weaveffi_graphics_Canvas* ptr);
+WEAVEFFI_API weaveffi_graphics_shapes_Shape* weaveffi_graphics_Canvas_get_root(const weaveffi_graphics_Canvas* ptr);
 
 /** Construct a Canvas. */
-weaveffi_graphics_Canvas* weaveffi_graphics_new_canvas(int32_t width, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_graphics_Canvas* weaveffi_graphics_new_canvas(int32_t width, weaveffi_error* out_err);
 
 /** A struct one level deep that references both an ancestor enum and a deeper struct. */
-weaveffi_graphics_shapes_Shape* weaveffi_graphics_shapes_Shape_create(int32_t sides, weaveffi_graphics_Unit unit, const weaveffi_graphics_shapes_geometry_Detail* detail, weaveffi_error* out_err);
-void weaveffi_graphics_shapes_Shape_destroy(weaveffi_graphics_shapes_Shape* ptr);
-int32_t weaveffi_graphics_shapes_Shape_get_sides(const weaveffi_graphics_shapes_Shape* ptr);
+WEAVEFFI_API weaveffi_graphics_shapes_Shape* weaveffi_graphics_shapes_Shape_create(int32_t sides, weaveffi_graphics_Unit unit, const weaveffi_graphics_shapes_geometry_Detail* detail, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_graphics_shapes_Shape_destroy(weaveffi_graphics_shapes_Shape* ptr);
+WEAVEFFI_API int32_t weaveffi_graphics_shapes_Shape_get_sides(const weaveffi_graphics_shapes_Shape* ptr);
 /** Reference up to the parent module's enum */
-weaveffi_graphics_Unit weaveffi_graphics_shapes_Shape_get_unit(const weaveffi_graphics_shapes_Shape* ptr);
+WEAVEFFI_API weaveffi_graphics_Unit weaveffi_graphics_shapes_Shape_get_unit(const weaveffi_graphics_shapes_Shape* ptr);
 /** Reference down into a deeper module */
-weaveffi_graphics_shapes_geometry_Detail* weaveffi_graphics_shapes_Shape_get_detail(const weaveffi_graphics_shapes_Shape* ptr);
+WEAVEFFI_API weaveffi_graphics_shapes_geometry_Detail* weaveffi_graphics_shapes_Shape_get_detail(const weaveffi_graphics_shapes_Shape* ptr);
 
 /** Construct a Shape. */
-weaveffi_graphics_shapes_Shape* weaveffi_graphics_shapes_make_shape(int32_t sides, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_graphics_shapes_Shape* weaveffi_graphics_shapes_make_shape(int32_t sides, weaveffi_error* out_err);
 /** Nested function returning a struct owned by an ancestor module. */
-weaveffi_graphics_Canvas* weaveffi_graphics_shapes_describe(weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_graphics_Canvas* weaveffi_graphics_shapes_describe(weaveffi_error* out_err);
 
 /** A struct two levels deep. */
-weaveffi_graphics_shapes_geometry_Detail* weaveffi_graphics_shapes_geometry_Detail_create(double area, weaveffi_error* out_err);
-void weaveffi_graphics_shapes_geometry_Detail_destroy(weaveffi_graphics_shapes_geometry_Detail* ptr);
-double weaveffi_graphics_shapes_geometry_Detail_get_area(const weaveffi_graphics_shapes_geometry_Detail* ptr);
+WEAVEFFI_API weaveffi_graphics_shapes_geometry_Detail* weaveffi_graphics_shapes_geometry_Detail_create(double area, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_graphics_shapes_geometry_Detail_destroy(weaveffi_graphics_shapes_geometry_Detail* ptr);
+WEAVEFFI_API double weaveffi_graphics_shapes_geometry_Detail_get_area(const weaveffi_graphics_shapes_geometry_Detail* ptr);
 
 /** Deeper function taking an ancestor-module struct. */
-weaveffi_graphics_shapes_geometry_Detail* weaveffi_graphics_shapes_geometry_compute(const weaveffi_graphics_shapes_Shape* shape, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_graphics_shapes_geometry_Detail* weaveffi_graphics_shapes_geometry_compute(const weaveffi_graphics_shapes_Shape* shape, weaveffi_error* out_err);
 
 } // extern "C"
 

--- a/crates/weaveffi-cli/tests/snapshots/cpp_shapes__weaveffi_hpp.snap
+++ b/crates/weaveffi-cli/tests/snapshots/cpp_shapes__weaveffi_hpp.snap
@@ -15,21 +15,45 @@ source: crates/weaveffi-cli/tests/snapshots.rs
 #include <memory>
 #include <stdexcept>
 
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+
+#ifndef WEAVEFFI_DEPRECATED
+#  if defined(_MSC_VER)
+#    define WEAVEFFI_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define WEAVEFFI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define WEAVEFFI_DEPRECATED(msg)
+#  endif
+#endif
+
 extern "C" {
 
 typedef uint64_t weaveffi_handle_t;
 
 typedef struct weaveffi_error { int32_t code; const char* message; } weaveffi_error;
 
-void weaveffi_error_clear(weaveffi_error* err);
-void weaveffi_free_string(const char* ptr);
-void weaveffi_free_bytes(uint8_t* ptr, size_t len);
+WEAVEFFI_API void weaveffi_error_clear(weaveffi_error* err);
+WEAVEFFI_API void weaveffi_free_string(const char* ptr);
+WEAVEFFI_API void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 
 typedef struct weaveffi_cancel_token weaveffi_cancel_token;
-weaveffi_cancel_token* weaveffi_cancel_token_create(void);
-void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
-bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
-void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
+WEAVEFFI_API weaveffi_cancel_token* weaveffi_cancel_token_create(void);
+WEAVEFFI_API void weaveffi_cancel_token_cancel(weaveffi_cancel_token* token);
+WEAVEFFI_API bool weaveffi_cancel_token_is_cancelled(const weaveffi_cancel_token* token);
+WEAVEFFI_API void weaveffi_cancel_token_destroy(weaveffi_cancel_token* token);
 
 /** An algebraic shape (sum type with associated data) */
 typedef enum {
@@ -50,50 +74,50 @@ typedef struct weaveffi_shapes_Shape weaveffi_shapes_Shape;
 typedef struct weaveffi_shapes_Numerics weaveffi_shapes_Numerics;
 
 /** An algebraic shape (sum type with associated data) */
-int32_t weaveffi_shapes_Shape_tag(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API int32_t weaveffi_shapes_Shape_tag(const weaveffi_shapes_Shape* self);
 /** The empty shape (a unit variant) */
-weaveffi_shapes_Shape* weaveffi_shapes_Shape_Empty_new(weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_shapes_Shape* weaveffi_shapes_Shape_Empty_new(weaveffi_error* out_err);
 /** A circle with a radius */
-weaveffi_shapes_Shape* weaveffi_shapes_Shape_Circle_new(double radius, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_shapes_Shape* weaveffi_shapes_Shape_Circle_new(double radius, weaveffi_error* out_err);
 /** Radius in points */
-double weaveffi_shapes_Shape_Circle_get_radius(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API double weaveffi_shapes_Shape_Circle_get_radius(const weaveffi_shapes_Shape* self);
 /** An axis-aligned rectangle */
-weaveffi_shapes_Shape* weaveffi_shapes_Shape_Rectangle_new(float width, float height, weaveffi_error* out_err);
-float weaveffi_shapes_Shape_Rectangle_get_width(const weaveffi_shapes_Shape* self);
-float weaveffi_shapes_Shape_Rectangle_get_height(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API weaveffi_shapes_Shape* weaveffi_shapes_Shape_Rectangle_new(float width, float height, weaveffi_error* out_err);
+WEAVEFFI_API float weaveffi_shapes_Shape_Rectangle_get_width(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API float weaveffi_shapes_Shape_Rectangle_get_height(const weaveffi_shapes_Shape* self);
 /** An integer-bounded shape (exercises narrow + wide ints) */
-weaveffi_shapes_Shape* weaveffi_shapes_Shape_Bounded_new(int16_t min, int16_t max, uint64_t weight, weaveffi_error* out_err);
-int16_t weaveffi_shapes_Shape_Bounded_get_min(const weaveffi_shapes_Shape* self);
-int16_t weaveffi_shapes_Shape_Bounded_get_max(const weaveffi_shapes_Shape* self);
-uint64_t weaveffi_shapes_Shape_Bounded_get_weight(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API weaveffi_shapes_Shape* weaveffi_shapes_Shape_Bounded_new(int16_t min, int16_t max, uint64_t weight, weaveffi_error* out_err);
+WEAVEFFI_API int16_t weaveffi_shapes_Shape_Bounded_get_min(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API int16_t weaveffi_shapes_Shape_Bounded_get_max(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API uint64_t weaveffi_shapes_Shape_Bounded_get_weight(const weaveffi_shapes_Shape* self);
 /** A labeled shape with a small count */
-weaveffi_shapes_Shape* weaveffi_shapes_Shape_Labeled_new(const char* label, uint8_t count, weaveffi_error* out_err);
-const char* weaveffi_shapes_Shape_Labeled_get_label(const weaveffi_shapes_Shape* self);
-uint8_t weaveffi_shapes_Shape_Labeled_get_count(const weaveffi_shapes_Shape* self);
-void weaveffi_shapes_Shape_destroy(weaveffi_shapes_Shape* self);
+WEAVEFFI_API weaveffi_shapes_Shape* weaveffi_shapes_Shape_Labeled_new(const char* label, uint8_t count, weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_shapes_Shape_Labeled_get_label(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API uint8_t weaveffi_shapes_Shape_Labeled_get_count(const weaveffi_shapes_Shape* self);
+WEAVEFFI_API void weaveffi_shapes_Shape_destroy(weaveffi_shapes_Shape* self);
 
 /** One field per supported numeric primitive */
-weaveffi_shapes_Numerics* weaveffi_shapes_Numerics_create(int8_t a, int16_t b, int32_t c, int64_t d, uint8_t e, uint16_t f, uint32_t g, uint64_t h, float i, double j, weaveffi_error* out_err);
-void weaveffi_shapes_Numerics_destroy(weaveffi_shapes_Numerics* ptr);
-int8_t weaveffi_shapes_Numerics_get_a(const weaveffi_shapes_Numerics* ptr);
-int16_t weaveffi_shapes_Numerics_get_b(const weaveffi_shapes_Numerics* ptr);
-int32_t weaveffi_shapes_Numerics_get_c(const weaveffi_shapes_Numerics* ptr);
-int64_t weaveffi_shapes_Numerics_get_d(const weaveffi_shapes_Numerics* ptr);
-uint8_t weaveffi_shapes_Numerics_get_e(const weaveffi_shapes_Numerics* ptr);
-uint16_t weaveffi_shapes_Numerics_get_f(const weaveffi_shapes_Numerics* ptr);
-uint32_t weaveffi_shapes_Numerics_get_g(const weaveffi_shapes_Numerics* ptr);
-uint64_t weaveffi_shapes_Numerics_get_h(const weaveffi_shapes_Numerics* ptr);
-float weaveffi_shapes_Numerics_get_i(const weaveffi_shapes_Numerics* ptr);
-double weaveffi_shapes_Numerics_get_j(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API weaveffi_shapes_Numerics* weaveffi_shapes_Numerics_create(int8_t a, int16_t b, int32_t c, int64_t d, uint8_t e, uint16_t f, uint32_t g, uint64_t h, float i, double j, weaveffi_error* out_err);
+WEAVEFFI_API void weaveffi_shapes_Numerics_destroy(weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API int8_t weaveffi_shapes_Numerics_get_a(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API int16_t weaveffi_shapes_Numerics_get_b(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API int32_t weaveffi_shapes_Numerics_get_c(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API int64_t weaveffi_shapes_Numerics_get_d(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API uint8_t weaveffi_shapes_Numerics_get_e(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API uint16_t weaveffi_shapes_Numerics_get_f(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API uint32_t weaveffi_shapes_Numerics_get_g(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API uint64_t weaveffi_shapes_Numerics_get_h(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API float weaveffi_shapes_Numerics_get_i(const weaveffi_shapes_Numerics* ptr);
+WEAVEFFI_API double weaveffi_shapes_Numerics_get_j(const weaveffi_shapes_Numerics* ptr);
 
 /** Render a shape to a string */
-const char* weaveffi_shapes_describe(const weaveffi_shapes_Shape* shape, weaveffi_error* out_err);
+WEAVEFFI_API const char* weaveffi_shapes_describe(const weaveffi_shapes_Shape* shape, weaveffi_error* out_err);
 /** Scale a shape by a factor, returning a new shape */
-weaveffi_shapes_Shape* weaveffi_shapes_scale(const weaveffi_shapes_Shape* shape, double factor, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_shapes_Shape* weaveffi_shapes_scale(const weaveffi_shapes_Shape* shape, double factor, weaveffi_error* out_err);
 /** Sum a list of bytes into a wide integer (numerics smoke) */
-uint64_t weaveffi_shapes_sum_bytes(const uint8_t* values, size_t values_len, weaveffi_error* out_err);
+WEAVEFFI_API uint64_t weaveffi_shapes_sum_bytes(const uint8_t* values, size_t values_len, weaveffi_error* out_err);
 /** Build a Numerics struct from every numeric primitive */
-weaveffi_shapes_Numerics* weaveffi_shapes_make_numerics(int8_t a, int16_t b, int32_t c, int64_t d, uint8_t e, uint16_t f, uint32_t g, uint64_t h, float i, double j, weaveffi_error* out_err);
+WEAVEFFI_API weaveffi_shapes_Numerics* weaveffi_shapes_make_numerics(int8_t a, int16_t b, int32_t c, int64_t d, uint8_t e, uint16_t f, uint32_t g, uint64_t h, float i, double j, weaveffi_error* out_err);
 
 } // extern "C"
 

--- a/crates/weaveffi-core/src/cabi.rs
+++ b/crates/weaveffi-core/src/cabi.rs
@@ -30,11 +30,82 @@ pub fn params_str(params: &[AbiParam], prefix: &str) -> String {
         .join(", ")
 }
 
-/// Render a full `{ret} {symbol}({params});` declaration for a lowered symbol.
+/// The export-visibility macro name for `prefix`, for example `WEAVEFFI_API`.
+///
+/// Every exported function prototype is tagged with this macro so a non-Rust
+/// producer that implements the header can export the symbols under hidden
+/// default visibility, and Windows consumers import them through `dllimport`.
+/// See [`render_visibility_macros`] for the macro's definition.
+fn export_macro(prefix: &str) -> String {
+    format!("{}_API", prefix.to_uppercase())
+}
+
+/// The deprecation macro name for `prefix`, for example `WEAVEFFI_DEPRECATED`.
+///
+/// Used in place of a bare `__attribute__((deprecated))` so the marker also
+/// compiles under MSVC (which spells it `__declspec(deprecated(...))`).
+fn deprecated_macro(prefix: &str) -> String {
+    format!("{}_DEPRECATED", prefix.to_uppercase())
+}
+
+/// Render the portable export-visibility and deprecation macros that the C ABI
+/// declarations are tagged with.
+///
+/// The C ABI header is both consumed (callers link the prebuilt library) and,
+/// for non-Rust producers, implemented directly (C, C++, or Zig supply the
+/// symbols). A bare prototype exports nothing under hidden default visibility
+/// (`-fvisibility=hidden`, the norm for release builds and the MSVC default),
+/// so an implementing library compiled that way ships no usable symbols. These
+/// macros fix that portably:
+///
+/// - `{PREFIX}_API` expands to `__declspec(dllexport)` when the producer
+///   defines `{PREFIX}_BUILD`, `__declspec(dllimport)` otherwise on Windows,
+///   `__attribute__((visibility("default")))` on GCC and Clang, and nothing
+///   elsewhere.
+/// - `{PREFIX}_DEPRECATED(msg)` expands to the compiler's deprecation marker.
+///
+/// Both definitions are wrapped in `#ifndef` guards so a translation unit that
+/// includes both the C header and the C++ header (which inlines the same
+/// declarations) defines each macro only once. The names are derived from the
+/// configured symbol prefix so two WeaveFFI libraries included together never
+/// collide.
+pub fn render_visibility_macros(out: &mut String, prefix: &str) {
+    let body = r#"#ifndef @U@_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef @U@_BUILD
+#      define @U@_API __declspec(dllexport)
+#    else
+#      define @U@_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define @U@_API __attribute__((visibility("default")))
+#  else
+#    define @U@_API
+#  endif
+#endif
+
+#ifndef @U@_DEPRECATED
+#  if defined(_MSC_VER)
+#    define @U@_DEPRECATED(msg) __declspec(deprecated(msg))
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define @U@_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#  else
+#    define @U@_DEPRECATED(msg)
+#  endif
+#endif
+
+"#;
+    out.push_str(&body.replace("@U@", &prefix.to_uppercase()));
+}
+
+/// Render a full `{API} {ret} {symbol}({params});` declaration for a lowered
+/// symbol, tagged with the export-visibility macro (see
+/// [`render_visibility_macros`]).
 pub fn fn_decl(out: &mut String, f: &AbiFn, prefix: &str) {
     let _ = writeln!(
         out,
-        "{} {}({});",
+        "{} {} {}({});",
+        export_macro(prefix),
         f.ret.render_c(prefix),
         f.symbol,
         params_str(&f.params, prefix)
@@ -44,18 +115,19 @@ pub fn fn_decl(out: &mut String, f: &AbiFn, prefix: &str) {
 /// Render the runtime typedefs and helper prototypes (`handle_t`, `error`,
 /// `free_*`, `cancel_token`) that every WeaveFFI C surface depends on.
 pub fn render_runtime_decls(out: &mut String, prefix: &str) {
+    let api = export_macro(prefix);
     let _ = write!(
         out,
         "typedef uint64_t {prefix}_handle_t;\n\n\
          typedef struct {prefix}_error {{ int32_t code; const char* message; }} {prefix}_error;\n\n\
-         void {prefix}_error_clear({prefix}_error* err);\n\
-         void {prefix}_free_string(const char* ptr);\n\
-         void {prefix}_free_bytes(uint8_t* ptr, size_t len);\n\n\
+         {api} void {prefix}_error_clear({prefix}_error* err);\n\
+         {api} void {prefix}_free_string(const char* ptr);\n\
+         {api} void {prefix}_free_bytes(uint8_t* ptr, size_t len);\n\n\
          typedef struct {prefix}_cancel_token {prefix}_cancel_token;\n\
-         {prefix}_cancel_token* {prefix}_cancel_token_create(void);\n\
-         void {prefix}_cancel_token_cancel({prefix}_cancel_token* token);\n\
-         bool {prefix}_cancel_token_is_cancelled(const {prefix}_cancel_token* token);\n\
-         void {prefix}_cancel_token_destroy({prefix}_cancel_token* token);\n\n",
+         {api} {prefix}_cancel_token* {prefix}_cancel_token_create(void);\n\
+         {api} void {prefix}_cancel_token_cancel({prefix}_cancel_token* token);\n\
+         {api} bool {prefix}_cancel_token_is_cancelled(const {prefix}_cancel_token* token);\n\
+         {api} void {prefix}_cancel_token_destroy({prefix}_cancel_token* token);\n\n",
     );
 }
 
@@ -108,9 +180,10 @@ fn render_rich_enum_fn_decls(out: &mut String, e: &EnumBinding, prefix: &str) {
     let Some(rich) = &e.rich else {
         return;
     };
+    let api = export_macro(prefix);
     let tag = &e.c_tag;
     emit_doc(out, &e.doc, "");
-    let _ = writeln!(out, "int32_t {}(const {tag}* self);", rich.tag_symbol);
+    let _ = writeln!(out, "{api} int32_t {}(const {tag}* self);", rich.tag_symbol);
     for v in &rich.variants {
         emit_doc(out, &v.doc, "");
         fn_decl(out, &v.create, prefix);
@@ -125,14 +198,14 @@ fn render_rich_enum_fn_decls(out: &mut String, e: &EnumBinding, prefix: &str) {
             );
             let _ = writeln!(
                 out,
-                "{} {}({});",
+                "{api} {} {}({});",
                 field.getter_ret.render_c(prefix),
                 field.getter_symbol,
                 parts.join(", ")
             );
         }
     }
-    let _ = writeln!(out, "void {}({tag}* self);", rich.destroy_symbol);
+    let _ = writeln!(out, "{api} void {}({tag}* self);", rich.destroy_symbol);
     out.push('\n');
 }
 
@@ -155,10 +228,11 @@ fn render_struct_tags(out: &mut String, s: &StructBinding) {
 /// struct (and every other struct it may reference) already has a forward
 /// typedef emitted via [`render_struct_tags`].
 fn render_struct_fn_decls(out: &mut String, s: &StructBinding, prefix: &str) {
+    let api = export_macro(prefix);
     let tag = &s.c_tag;
     emit_doc(out, &s.doc, "");
     fn_decl(out, &s.create, prefix);
-    let _ = writeln!(out, "void {}({tag}* ptr);", s.destroy_symbol);
+    let _ = writeln!(out, "{api} void {}({tag}* ptr);", s.destroy_symbol);
     for field in &s.fields {
         emit_doc(out, &field.doc, "");
         let mut parts = vec![format!("const {tag}* ptr")];
@@ -170,7 +244,7 @@ fn render_struct_fn_decls(out: &mut String, s: &StructBinding, prefix: &str) {
         );
         let _ = writeln!(
             out,
-            "{} {}({});",
+            "{api} {} {}({});",
             field.getter_ret.render_c(prefix),
             field.getter_symbol,
             parts.join(", ")
@@ -180,21 +254,21 @@ fn render_struct_fn_decls(out: &mut String, s: &StructBinding, prefix: &str) {
 
     if let Some(b) = &s.builder {
         let bt = &b.builder_tag;
-        let _ = writeln!(out, "{bt}* {}(void);", b.new_symbol);
+        let _ = writeln!(out, "{api} {bt}* {}(void);", b.new_symbol);
         for (field, (_, setter)) in s.fields.iter().zip(&b.setters) {
             emit_doc(out, &field.doc, "");
             let _ = writeln!(
                 out,
-                "void {setter}({bt}* builder, {});",
+                "{api} void {setter}({bt}* builder, {});",
                 params_str(&field.value_params, prefix)
             );
         }
         let _ = writeln!(
             out,
-            "{tag}* {}({bt}* builder, {prefix}_error* out_err);",
+            "{api} {tag}* {}({bt}* builder, {prefix}_error* out_err);",
             b.build_symbol
         );
-        let _ = writeln!(out, "void {}({bt}* builder);", b.destroy_symbol);
+        let _ = writeln!(out, "{api} void {}({bt}* builder);", b.destroy_symbol);
         out.push('\n');
     }
 }
@@ -263,6 +337,8 @@ pub fn render_module_callback_types(out: &mut String, module: &ModuleBinding, pr
 /// type tags and callback typedefs are assumed already emitted (phases 1a–1c).
 /// Caller controls the leading `// Module:` comment and any framing.
 pub fn render_module_fn_decls(out: &mut String, module: &ModuleBinding, prefix: &str) {
+    let api = export_macro(prefix);
+    let deprecated = deprecated_macro(prefix);
     for e in &module.enums {
         render_rich_enum_fn_decls(out, e, prefix);
     }
@@ -273,27 +349,23 @@ pub fn render_module_fn_decls(out: &mut String, module: &ModuleBinding, prefix: 
         emit_doc(out, &l.doc, "");
         let _ = writeln!(
             out,
-            "uint64_t {}({} callback, void* context);",
+            "{api} uint64_t {}({} callback, void* context);",
             l.register_symbol, l.callback_c_fn_type
         );
         emit_doc(out, &l.doc, "");
-        let _ = writeln!(out, "void {}(uint64_t id);", l.unregister_symbol);
+        let _ = writeln!(out, "{api} void {}(uint64_t id);", l.unregister_symbol);
     }
     for f in &module.functions {
         emit_doc(out, &f.doc, "");
         if let Some(msg) = &f.deprecated {
-            let _ = writeln!(
-                out,
-                "__attribute__((deprecated(\"{}\")))",
-                msg.replace('"', "\\\"")
-            );
+            let _ = writeln!(out, "{deprecated}(\"{}\")", msg.replace('"', "\\\""));
         }
         match &f.shape {
             CallShape::Iterator(it) => {
                 let t = &it.iter_tag;
                 fn_decl(out, &it.launch, prefix);
                 fn_decl(out, &it.next, prefix);
-                let _ = writeln!(out, "void {}({t}* iter);", it.destroy_symbol);
+                let _ = writeln!(out, "{api} void {}({t}* iter);", it.destroy_symbol);
             }
             CallShape::Async(a) => {
                 fn_decl(out, &a.launch, prefix);

--- a/crates/weaveffi-gen-c/src/lib.rs
+++ b/crates/weaveffi-gen-c/src/lib.rs
@@ -246,6 +246,7 @@ pub fn render_c_header_from_model(
     out.push_str("#include <stdint.h>\n");
     out.push_str("#include <stddef.h>\n");
     out.push_str("#include <stdbool.h>\n\n");
+    cabi::render_visibility_macros(&mut out, prefix);
     out.push_str(&render_abi_prefix_aliases(prefix));
     out.push_str("#ifdef __cplusplus\nextern \"C\" {\n#endif\n\n");
     cabi::render_runtime_decls(&mut out, prefix);
@@ -418,6 +419,63 @@ mod tests {
         assert!(h.contains("#ifndef ACME_H"));
         assert!(h.contains("void acme_net_ping(acme_error* out_err);"));
         assert!(h.contains("#define acme_error weaveffi_error"));
+    }
+
+    #[test]
+    fn visibility_macro_defined_and_applied_to_prototypes() {
+        let m = Module {
+            functions: vec![func(
+                "add",
+                vec![param("a", TypeRef::I32), param("b", TypeRef::I32)],
+                Some(TypeRef::I32),
+            )],
+            ..module("math")
+        };
+        let h = header(&api(vec![m]), "weaveffi");
+        // The macro is defined behind an include guard with the three branches.
+        assert!(h.contains("#ifndef WEAVEFFI_API"));
+        assert!(h.contains("#      define WEAVEFFI_API __declspec(dllexport)"));
+        assert!(h.contains("#      define WEAVEFFI_API __declspec(dllimport)"));
+        assert!(h.contains("#    define WEAVEFFI_API __attribute__((visibility(\"default\")))"));
+        // Both runtime helpers and user functions carry the export tag.
+        assert!(h.contains("WEAVEFFI_API void weaveffi_free_string(const char* ptr);"));
+        assert!(h.contains(
+            "WEAVEFFI_API int32_t weaveffi_math_add(int32_t a, int32_t b, weaveffi_error* out_err);"
+        ));
+        // Type definitions are never tagged: they declare no exported symbol.
+        assert!(h.contains("typedef uint64_t weaveffi_handle_t;"));
+        assert!(!h.contains("WEAVEFFI_API typedef"));
+    }
+
+    #[test]
+    fn visibility_macro_follows_custom_prefix() {
+        let m = Module {
+            functions: vec![func("ping", vec![], None)],
+            ..module("net")
+        };
+        let h = header(&api(vec![m]), "acme");
+        assert!(h.contains("#ifndef ACME_API"));
+        assert!(h.contains("ifdef ACME_BUILD"));
+        assert!(h.contains("ACME_API void acme_net_ping(acme_error* out_err);"));
+        // The default-prefixed macro must not leak when a prefix is configured.
+        assert!(!h.contains("WEAVEFFI_API"));
+    }
+
+    #[test]
+    fn deprecated_uses_portable_macro_not_bare_attribute() {
+        let m = Module {
+            functions: vec![Function {
+                deprecated: Some("use bar instead".into()),
+                ..func("foo", vec![], None)
+            }],
+            ..module("legacy")
+        };
+        let h = header(&api(vec![m]), "weaveffi");
+        assert!(h.contains("#ifndef WEAVEFFI_DEPRECATED"));
+        assert!(h.contains("WEAVEFFI_DEPRECATED(\"use bar instead\")"));
+        // The message must travel through the macro, never a bare GCC attribute
+        // (which MSVC cannot parse).
+        assert!(!h.contains("__attribute__((deprecated(\"use bar instead\")))"));
     }
 
     #[test]

--- a/crates/weaveffi-gen-cpp/src/lib.rs
+++ b/crates/weaveffi-gen-cpp/src/lib.rs
@@ -358,6 +358,7 @@ fn render_cpp_header(
     }
     out.push('\n');
 
+    cabi::render_visibility_macros(&mut out, c_prefix);
     out.push_str(&render_abi_prefix_aliases(c_prefix));
     out.push_str("extern \"C\" {\n\n");
     render_extern_c(&mut out, api, c_prefix);
@@ -2643,6 +2644,29 @@ mod tests {
         assert!(
             h.contains("void weaveffi_free_bytes(uint8_t* ptr, size_t len);"),
             "missing free_bytes"
+        );
+    }
+
+    #[test]
+    fn visibility_macro_defined_and_applied() {
+        let h = render_cpp_header(
+            &minimal_api(),
+            "weaveffi",
+            "weaveffi",
+            "weaveffi.yml",
+            "weaveffi.hpp",
+        );
+        // Defined once behind a guard so a translation unit that includes both
+        // weaveffi.h and weaveffi.hpp does not redefine it.
+        assert!(h.contains("#ifndef WEAVEFFI_API"), "missing macro guard");
+        assert!(
+            h.contains("#    define WEAVEFFI_API __attribute__((visibility(\"default\")))"),
+            "missing GCC/Clang visibility branch"
+        );
+        // The inlined extern \"C\" declarations carry the export tag.
+        assert!(
+            h.contains("WEAVEFFI_API void weaveffi_free_string(const char* ptr);"),
+            "runtime helper not tagged for export"
         );
     }
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -150,7 +150,12 @@ Rust, no platform-specific dependencies). Generated outputs target
 Windows correctly:
 
 - **C / C++**: emitted headers are compiler-agnostic (MSVC, clang,
-  gcc).
+  gcc), and every prototype carries a portable `WEAVEFFI_API`
+  visibility macro. Consumers resolve it to `__declspec(dllimport)`;
+  a C/C++/Zig backend that implements the header builds its library
+  with `WEAVEFFI_BUILD` defined to export the symbols via
+  `__declspec(dllexport)` (see the
+  [C generator docs](generators/c.md#symbol-visibility)).
 - **.NET**: P/Invoke uses `DllImport` with the right calling
   conventions and looks up `weaveffi.dll`.
 - **Node.js**: the N-API addon builds with `node-gyp` on Windows.

--- a/docs/src/generators/c.md
+++ b/docs/src/generators/c.md
@@ -133,6 +133,11 @@ void weaveffi_free_string(const char* ptr);
 void weaveffi_free_bytes(uint8_t* ptr, size_t len);
 ```
 
+In the real output each prototype is prefixed with a `WEAVEFFI_API` visibility
+macro (and deprecated functions with `WEAVEFFI_DEPRECATED`), omitted here for
+brevity. See [Symbol visibility](#symbol-visibility) for what it does and when
+you need it.
+
 Structs become forward-declared opaque typedefs reached via
 create/destroy/getter functions:
 
@@ -184,6 +189,55 @@ if (err.code != 0) {
     return 1;
 }
 ```
+
+## Symbol visibility
+
+Every function prototype is tagged with a `WEAVEFFI_API` macro that the header
+defines near the top:
+
+```c
+#ifndef WEAVEFFI_API
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    ifdef WEAVEFFI_BUILD
+#      define WEAVEFFI_API __declspec(dllexport)
+#    else
+#      define WEAVEFFI_API __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__) && (__GNUC__ >= 4)
+#    define WEAVEFFI_API __attribute__((visibility("default")))
+#  else
+#    define WEAVEFFI_API
+#  endif
+#endif
+```
+
+This covers the two ways the header is used:
+
+- **Consuming** a prebuilt library (the common case) needs nothing extra. On
+  Windows the prototypes resolve to `__declspec(dllimport)`; everywhere else the
+  macro is harmless.
+- **Implementing** the header (a C, C++, or Zig backend that supplies the
+  symbols instead of calling them) relies on the macro to stay exportable. Under
+  hidden default visibility (`-fvisibility=hidden`, the release-build norm and
+  the MSVC default) an untagged definition is local and ships no usable symbol.
+  On GCC and Clang the macro applies `visibility("default")`, so your
+  definitions export with no extra flags.
+
+When you implement the header on Windows, compile your library with
+`WEAVEFFI_BUILD` defined so the macro switches to `__declspec(dllexport)`:
+
+```sh
+cc -DWEAVEFFI_BUILD -shared mylib.c -o mylib.dll
+```
+
+Deprecated functions carry a companion `WEAVEFFI_DEPRECATED("...")` macro that
+expands to `__declspec(deprecated(...))` on MSVC and
+`__attribute__((deprecated(...)))` on GCC and Clang.
+
+When the IDL sets `c_prefix`, both macros follow it: a `c_prefix` of `acme`
+yields `ACME_API`, `ACME_BUILD`, and `ACME_DEPRECATED`, so two
+WeaveFFI-generated libraries can coexist in one translation unit without
+colliding.
 
 ## Rich (algebraic) enums
 


### PR DESCRIPTION
## Summary

Generated C and C++ headers now tag every exported prototype with a portable `WEAVEFFI_API` visibility macro, so a non-Rust backend that implements the header exports its symbols even under hidden default visibility (`-fvisibility=hidden`, the release-build norm and the MSVC default). Consumers resolve it to `__declspec(dllimport)` on Windows; it's benign elsewhere. Deprecated functions use a companion `WEAVEFFI_DEPRECATED` macro that also compiles under MSVC.

## Changes

- Tag all C ABI prototypes (runtime helpers, functions, struct/enum ops) via the shared `cabi` renderer; emit the macro definitions from the C and C++ generators.
- Replace the bare `__attribute__((deprecated))` with a portable `WEAVEFFI_DEPRECATED` macro.
- Add a producer-side conformance lane that builds an implementing C library under `-fvisibility=hidden` and asserts symbols export.
- Regenerate C/C++ snapshots; document the macro in the C generator docs and FAQ.

Closes #23