### PR TITLE
feat!: add callback and listener support to the wasm generator

### DIFF
--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -437,8 +437,9 @@ kotlin_shapes()  { kotlin_consumer shapes shapes.kt; }
 # Wasm: compile the producer to wasm32-unknown-unknown and drive the generated
 # ESM bindings from Node. The generated JS glue expects weaveffi_alloc/dealloc
 # plus an exported, growable __indirect_function_table, wired by the workspace
-# .cargo/config.toml (--export-table/--growable-table). Async wrappers build host
-# trampolines with WebAssembly.Function, which needs the type-reflection flag.
+# .cargo/config.toml (--export-table/--growable-table). Async and listener
+# wrappers build host trampolines with WebAssembly.Function, which needs the
+# type-reflection flag.
 # Unlike the cdylib lanes there is no FFI library to load: the .wasm is fully
 # self-contained and the consumer reads it via WV_WASM, with WV_JS pointing at
 # the generated module.

--- a/conformance/wasm/events.mjs
+++ b/conformance/wasm/events.mjs
@@ -1,13 +1,16 @@
 // Conformance consumer: events sample, Wasm (wasm32-unknown-unknown) target.
 //
-// The wasm target declares listeners/callbacks unsupported; the sample opts in
-// via `generators.wasm.allow_unsupported`, so the supported surface (send +
-// the iterator-drained get_messages) must work and the listener register/
-// unregister entry points must exist as explicit stubs that throw.
+// Exercises the function-table trampoline listener path (register -> the
+// producer's emit fires synchronously back into JS during sendMessage ->
+// unregister stops delivery) and the lazy iterable getMessages (one producer
+// next per step, drained here via spread). Unlike the native targets there
+// is no event-loop hop: wasm delivery is same-thread and synchronous, so
+// assertions run immediately after each send.
 //
 // Inputs come from the harness:
 //   WV_WASM: path to the compiled events.wasm
 //   WV_JS:   path to the generated weaveffi_wasm.js (ESM)
+// Run with: node --experimental-wasm-type-reflection (for WebAssembly.Function).
 
 import fs from 'fs';
 
@@ -31,10 +34,24 @@ function expect(cond, msg) {
   }
 }
 
+// Listener registration returns a plain numeric subscription id.
+const received = [];
+const sub = api.events.registerMessageListener((message) => received.push(message));
+expect(typeof sub === 'number' && sub > 0, 'listener id positive');
+
 // Functions surface in lowerCamelCase (module-prefix-free names under the
-// module object).
+// module object). Delivery is synchronous: the callback runs inside each
+// sendMessage call.
 api.events.sendMessage('alpha');
+expect(
+  received.length === 1 && received[0] === 'alpha',
+  `listener received first send synchronously (got ${JSON.stringify(received)})`
+);
 api.events.sendMessage('beta');
+expect(
+  received.length === 2 && received[1] === 'beta',
+  `listener received sends in order (got ${JSON.stringify(received)})`
+);
 
 // getMessages returns a lazy iterable (one producer next per step); spread
 // drains it here.
@@ -48,28 +65,15 @@ expect(
 // still exported for panic/marshalling failures.
 expect(typeof mod.WeaveFFIError === 'function', 'WeaveFFIError exported');
 
-// The unsupported listener surface throws with a clear message instead of
-// silently not existing.
-expect(typeof api.events.registerMessageListener === 'function', 'register stub exists');
-let threw = false;
-try {
-  api.events.registerMessageListener(() => {});
-} catch (e) {
-  threw = true;
-  expect(
-    String(e.message).includes('not supported by the wasm target'),
-    `stub error names the wasm target (got: ${e.message})`
-  );
-}
-expect(threw, 'register stub throws');
+// Unregister stops delivery; the producer still records the message.
+api.events.unregisterMessageListener(sub);
+api.events.sendMessage('gamma');
+expect(received.length === 2, `no delivery after unregister (got ${JSON.stringify(received)})`);
+expect([...api.events.getMessages()].length === 3, 'producer kept recording');
 
-let threwUnregister = false;
-try {
-  api.events.unregisterMessageListener(1);
-} catch (e) {
-  threwUnregister = true;
-}
-expect(threwUnregister, 'unregister stub throws');
+// Unregistering an unknown id is a harmless no-op.
+api.events.unregisterMessageListener(sub);
+api.events.unregisterMessageListener(999999);
 
 if (failures > 0) process.exit(1);
 console.log('wasm/events: OK');

--- a/conformance/wasm/kvstore.mjs
+++ b/conformance/wasm/kvstore.mjs
@@ -11,8 +11,9 @@
 // list getter (Entry.tags), the map getter (Entry.metadata over parallel
 // key/value arrays), a lazy iterator-backed string stream (listKeys), the
 // fluent builder + static create factory, the kv.stats submodule taking the
-// interface as a parameter, and the async, i64-returning compact via the
-// callback trampoline.
+// interface as a parameter, the async, i64-returning compact via the
+// callback trampoline, and the eviction listener via the long-lived
+// function-table trampoline (synchronous, same-thread delivery).
 //
 // Inputs come from the harness:
 //   WV_WASM: path to the compiled kvstore.wasm
@@ -142,13 +143,21 @@ expect(typeof reclaimed === 'bigint', 'compact -> BigInt');
 store.clear();
 expect(store.count() === 0n, 'count == 0 after clear');
 
-// The unsupported listener surface exists as explicit throwing stubs.
-expect(typeof api.kv.registerEvictionListener === 'function', 'listener stub exists');
-let listenerThrew = false;
-try { api.kv.registerEvictionListener(() => {}); } catch (e) {
-  listenerThrew = String(e.message).includes('not supported by the wasm target');
-}
-expect(listenerThrew, 'listener stub throws');
+// Eviction listener: delete fires emit_eviction_listener synchronously (wasm
+// delivery is same-thread; the callback runs inside the delete call).
+const evicted = [];
+const evictionSub = api.kv.registerEvictionListener((key) => evicted.push(key));
+expect(typeof evictionSub === 'number' && evictionSub > 0, 'eviction listener id positive');
+expect(store.put('doomed', new Uint8Array([1]), EntryKind.Volatile, null) === true, 'put doomed');
+expect(store.delete('doomed') === true, 'delete doomed -> true');
+expect(
+  evicted.length === 1 && evicted[0] === 'doomed',
+  `eviction listener fired synchronously (got ${JSON.stringify(evicted)})`
+);
+api.kv.unregisterEvictionListener(evictionSub);
+expect(store.put('doomed2', new Uint8Array([1]), EntryKind.Volatile, null) === true, 'put doomed2');
+expect(store.delete('doomed2') === true, 'delete doomed2 -> true');
+expect(evicted.length === 1, `no delivery after unregister (got ${JSON.stringify(evicted)})`);
 
 // Disposal: free() releases the handle via the destroy symbol exactly once.
 store.free();

--- a/crates/weaveffi-cli/benches/generate_bench.rs
+++ b/crates/weaveffi-cli/benches/generate_bench.rs
@@ -159,16 +159,9 @@ fn all_default_generators() -> Vec<Box<dyn DynGenerator>> {
             NodeGenerator,
             NodeConfig::default(),
         )),
-        // The kitchen-sink fixture uses callbacks/listeners, which the wasm
-        // target cannot deliver; opt in (mirroring `generators.wasm.
-        // allow_unsupported` in real IDLs) so the orchestrator benches can
-        // still fan out to all 11 targets.
         Box::new(ConfiguredGenerator::new(
             WasmGenerator,
-            WasmConfig {
-                allow_unsupported: true,
-                ..WasmConfig::default()
-            },
+            WasmConfig::default(),
         )),
         Box::new(ConfiguredGenerator::new(
             PythonGenerator,

--- a/crates/weaveffi-cli/src/config.rs
+++ b/crates/weaveffi-cli/src/config.rs
@@ -501,21 +501,16 @@ mod tests {
         use std::collections::BTreeMap;
         use weaveffi_core::capabilities::TargetCapabilities;
 
-        // Only wasm is partial: the browser sandbox cannot deliver
-        // producer-initiated callbacks/listeners. Every other target is full.
-        let wasm = TargetCapabilities {
-            async_functions: true,
-            callbacks: false,
-            listeners: false,
-            iterators: true,
-        };
+        // Every target is full. Wasm delivers callbacks/listeners
+        // synchronously through function-table trampolines in its standard
+        // loader (Emscripten mode stubs them, mirroring its async stubs).
         let expected: &[(&str, TargetCapabilities)] = &[
             ("c", TargetCapabilities::full()),
             ("cpp", TargetCapabilities::full()),
             ("swift", TargetCapabilities::full()),
             ("android", TargetCapabilities::full()),
             ("node", TargetCapabilities::full()),
-            ("wasm", wasm),
+            ("wasm", TargetCapabilities::full()),
             ("python", TargetCapabilities::full()),
             ("dotnet", TargetCapabilities::full()),
             ("dart", TargetCapabilities::full()),

--- a/crates/weaveffi-cli/tests/cli_inline_generators.rs
+++ b/crates/weaveffi-cli/tests/cli_inline_generators.rs
@@ -63,56 +63,14 @@ const LISTENER_IDL: &str = concat!(
     "          - { name: text, type: string }\n",
 );
 
-/// The wasm target declares callbacks/listeners unsupported, so generating a
-/// listener-bearing IDL for wasm must fail loudly with an actionable message.
+/// The wasm target supports listeners in its standard loader: a
+/// listener-bearing IDL generates real register/unregister bindings (no
+/// opt-in flag, no capability warning, no throwing stubs).
 #[test]
-fn wasm_rejects_listeners_without_opt_in() {
+fn wasm_generates_listener_bindings() {
     let dir = tempfile::tempdir().expect("failed to create temp dir");
     let yml = dir.path().join("api.yml");
     fs::write(&yml, LISTENER_IDL).expect("failed to write api.yml");
-    let out = dir.path().join("out");
-
-    let assert = assert_cmd::Command::cargo_bin("weaveffi")
-        .expect("binary not found")
-        .args([
-            "generate",
-            yml.to_str().unwrap(),
-            "-o",
-            out.to_str().unwrap(),
-            "--target",
-            "wasm",
-        ])
-        .assert()
-        .failure();
-
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
-    assert!(
-        stderr.contains("target 'wasm' does not support"),
-        "stderr should name the failing target:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("events.message_listener"),
-        "stderr should list the offending declaration:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("allow_unsupported"),
-        "stderr should mention the opt-in escape hatch:\n{stderr}"
-    );
-    assert!(!out.join("wasm").exists(), "no output should be written");
-}
-
-/// `generators.wasm.allow_unsupported: true` downgrades the capability
-/// failure to a warning; the supported surface generates and the listener
-/// becomes an explicit throwing stub.
-#[test]
-fn wasm_allow_unsupported_generates_with_warning() {
-    let dir = tempfile::tempdir().expect("failed to create temp dir");
-    let yml = dir.path().join("api.yml");
-    fs::write(
-        &yml,
-        format!("{LISTENER_IDL}generators:\n  wasm:\n    allow_unsupported: true\n"),
-    )
-    .expect("failed to write api.yml");
     let out = dir.path().join("out");
 
     let assert = assert_cmd::Command::cargo_bin("weaveffi")
@@ -130,30 +88,34 @@ fn wasm_allow_unsupported_generates_with_warning() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
     assert!(
-        stderr.contains("warning: target 'wasm'"),
-        "opting in must still print a warning:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("events.message_listener"),
-        "warning should list what was skipped:\n{stderr}"
+        !stderr.contains("does not support"),
+        "no capability warning should be printed:\n{stderr}"
     );
 
     let js = fs::read_to_string(out.join("wasm/weaveffi_wasm.js"))
         .expect("missing wasm/weaveffi_wasm.js");
     assert!(
-        js.contains("registerMessageListener() {"),
-        "listener should become an explicit stub:\n{js}"
+        js.contains("registerMessageListener(callback) {"),
+        "register should take the JS callback:\n{js}"
     );
     assert!(
-        js.contains("is not supported by the wasm target"),
-        "stub should throw with a clear message:\n{js}"
+        js.contains("wasm.weaveffi_events_register_message_listener("),
+        "register should call the producer symbol:\n{js}"
+    );
+    assert!(
+        !js.contains("is not supported by the wasm target"),
+        "no throwing stubs in the standard loader:\n{js}"
     );
 
     let dts = fs::read_to_string(out.join("wasm/weaveffi_wasm.d.ts"))
         .expect("missing wasm/weaveffi_wasm.d.ts");
     assert!(
-        !dts.contains("registerMessageListener"),
-        "d.ts should omit unsupported entry points:\n{dts}"
+        dts.contains("registerMessageListener(callback: (message: string) => void): number;"),
+        "d.ts should declare the register entry point:\n{dts}"
+    );
+    assert!(
+        dts.contains("unregisterMessageListener(id: number): void;"),
+        "d.ts should declare the unregister entry point:\n{dts}"
     );
 }
 

--- a/crates/weaveffi-cli/tests/no_silent_stubs.rs
+++ b/crates/weaveffi-cli/tests/no_silent_stubs.rs
@@ -93,8 +93,8 @@ fn generated_output_has_no_stub_markers() {
 
     // Case-insensitive marker list. Bare "not supported" is deliberately
     // absent: an explicit, permanently declared unsupported-feature surface
-    // (e.g. wasm listeners behind `allow_unsupported`, which throw "is not
-    // supported by the wasm target") is the *correct* loud behavior. The
+    // (e.g. wasm async/listener stubs in Emscripten mode, which throw "is
+    // not supported in Emscripten mode") is the *correct* loud behavior. The
     // "yet" in "not yet supported" is what distinguishes capability drift: a
     // target that declares a feature `true` (so the gate lets generation
     // through) but then emits a runtime-throwing TODO stub for it. That is

--- a/crates/weaveffi-cli/tests/snapshots/wasm_async_demo__weaveffi_wasm_js.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_async_demo__weaveffi_wasm_js.snap
@@ -232,9 +232,10 @@ export async function loadWeaveffiWasm(url) {
   const { instance } = await WebAssembly.instantiate(bytes, {});
   const wasm = instance.exports;
 
+  const _table = wasm.__indirect_function_table;
+
   let _nextCtxId = 1;
   const _asyncContexts = new Map();
-  const _table = wasm.__indirect_function_table;
 
   function _asyncHandler(ctxId, errPtr, ...results) {
     const ctx = _asyncContexts.get(ctxId);

--- a/crates/weaveffi-cli/tests/snapshots/wasm_docs_everywhere__README_md.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_docs_everywhere__README_md.snap
@@ -41,6 +41,12 @@ Lists are passed as a **pointer + length** pair (`i32` pointer, `i32` length) re
 
 `iter<T>` functions return a **lazy JS iterator** (typed `IterableIterator<T>`): each `next()` issues exactly one producer call, so iteration streams in constant memory. The producer handle is destroyed exactly once, on exhaustion or via `return()` when iteration stops early (a `for...of` loop calls `return()` automatically on `break` or `throw`). Abandoning an iterator without exhausting or closing it leaks the handle.
 
+### Callbacks and Listeners
+
+Each listener surfaces as a `register.../unregister...` pair. `register` takes a plain JS function and returns a numeric subscription id; `unregister` takes that id and stops delivery. Delivery is **synchronous and same-thread**: `wasm32-unknown-unknown` is single-threaded, so events fire only while a call into the module is on the stack (for example, a producer function that emits during its own execution). A producer that emits from a spawned thread cannot run on this target at all.
+
+Callback arguments are **borrowed for the duration of the callback**: strings and byte buffers are copied into JS values before your function runs, but struct, rich-enum, and interface arguments wrap producer-owned memory. Read what you need inside the callback and do not retain the wrapper or call `free()` on it.
+
 ### Error Handling
 
 The generated JS wrappers automatically handle errors by passing an error
@@ -57,19 +63,6 @@ Wrappers of functions declared `throws` raise the declaring module's typed
 error class (a `WeaveFFIError` subclass with a per-code subclass, such as
 `KeyNotFound`); every other wrapper raises the generic `WeaveFFIError` only
 for producer panics and marshalling failures.
-
-## Unsupported Features
-
-This IDL uses features the wasm target does not support (generated because
-`allow_unsupported` is set). Single-threaded `wasm32-unknown-unknown` has no
-producer thread to deliver events from, so:
-
-- **callbacks**: docs.OnSaved
-- **listeners**: docs.saved_listener
-
-The TypeScript declarations omit these entry points; the JS module exposes
-explicit stubs that throw on call. Use a native target (node, python, …) when
-you need them.
 
 ## API Reference
 

--- a/crates/weaveffi-cli/tests/snapshots/wasm_docs_everywhere__weaveffi_wasm_d_ts.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_docs_everywhere__weaveffi_wasm_d_ts.snap
@@ -127,6 +127,14 @@ export interface WeaveffiWasmModule {
      * @throws {WeaveFFIError} if the native call fails
      */
     publishAsync(id: bigint): Promise<boolean>;
+    /**
+     * Subscribe to document-saved notifications
+     *
+     * @returns A subscription id for `unregisterSavedListener()`.
+     */
+    registerSavedListener(callback: (docId: bigint, revision: number) => void): number;
+    /** Unregister a listener previously registered with `registerSavedListener()`. */
+    unregisterSavedListener(id: number): void;
     Notebook: typeof Notebook;
   };
 }

--- a/crates/weaveffi-cli/tests/snapshots/wasm_docs_everywhere__weaveffi_wasm_js.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_docs_everywhere__weaveffi_wasm_js.snap
@@ -326,9 +326,10 @@ export async function loadWeaveffiWasm(url) {
   const { instance } = await WebAssembly.instantiate(bytes, {});
   const wasm = instance.exports;
 
+  const _table = wasm.__indirect_function_table;
+
   let _nextCtxId = 1;
   const _asyncContexts = new Map();
-  const _table = wasm.__indirect_function_table;
 
   function _asyncHandler(ctxId, errPtr, ...results) {
     const ctx = _asyncContexts.get(ctxId);
@@ -343,6 +344,20 @@ export async function loadWeaveffiWasm(url) {
   }
 
   const _cbPtr_i32_i32_i32 = _registerTrampoline(_table, ['i32', 'i32', 'i32'], _asyncHandler);
+
+  // Listener subscriptions, keyed by the context id the loader
+  // threads through the C ABI's void* context slot. Each entry
+  // holds the JS callback and the producer's subscription id.
+  let _nextLsnId = 1;
+  const _listeners = new Map();
+
+  const _lsnPtr_weaveffi_docs_OnSaved_fn = _registerTrampoline(_table, ['i64', 'i32', 'i32'], (a0, a1, _ctx) => {
+    const _l = _listeners.get(_ctx);
+    if (_l === undefined) return;
+    const _p0 = a0;
+    const _p1 = a1;
+    _l.callback(_p0, _p1);
+  });
 
   // An ordered collection of documents.
   // 
@@ -433,11 +448,18 @@ export async function loadWeaveffiWasm(url) {
           wasm.weaveffi_docs_publish_async_async(BigInt(id), _cbPtr_i32_i32_i32, ctxId);
         });
       },
-      registerSavedListener() {
-        throw new Error("weaveffi: listener 'saved_listener' is not supported by the wasm target (single-threaded wasm has no producer thread to deliver events); use a native target for listeners");
+      /** Subscribe to document-saved notifications */
+      registerSavedListener(callback) {
+        const _id = _nextLsnId++;
+        const _rid = wasm.weaveffi_docs_register_saved_listener(_lsnPtr_weaveffi_docs_OnSaved_fn, _id);
+        _listeners.set(_id, { callback, rid: _rid });
+        return _id;
       },
-      unregisterSavedListener() {
-        throw new Error("weaveffi: listener 'saved_listener' is not supported by the wasm target (single-threaded wasm has no producer thread to deliver events); use a native target for listeners");
+      unregisterSavedListener(id) {
+        const _l = _listeners.get(id);
+        if (_l === undefined) return;
+        _listeners.delete(id);
+        wasm.weaveffi_docs_unregister_saved_listener(_l.rid);
       },
       Notebook: Notebook,
       Document: {

--- a/crates/weaveffi-cli/tests/snapshots/wasm_events__README_md.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_events__README_md.snap
@@ -41,6 +41,12 @@ Lists are passed as a **pointer + length** pair (`i32` pointer, `i32` length) re
 
 `iter<T>` functions return a **lazy JS iterator** (typed `IterableIterator<T>`): each `next()` issues exactly one producer call, so iteration streams in constant memory. The producer handle is destroyed exactly once, on exhaustion or via `return()` when iteration stops early (a `for...of` loop calls `return()` automatically on `break` or `throw`). Abandoning an iterator without exhausting or closing it leaks the handle.
 
+### Callbacks and Listeners
+
+Each listener surfaces as a `register.../unregister...` pair. `register` takes a plain JS function and returns a numeric subscription id; `unregister` takes that id and stops delivery. Delivery is **synchronous and same-thread**: `wasm32-unknown-unknown` is single-threaded, so events fire only while a call into the module is on the stack (for example, a producer function that emits during its own execution). A producer that emits from a spawned thread cannot run on this target at all.
+
+Callback arguments are **borrowed for the duration of the callback**: strings and byte buffers are copied into JS values before your function runs, but struct, rich-enum, and interface arguments wrap producer-owned memory. Read what you need inside the callback and do not retain the wrapper or call `free()` on it.
+
 ### Error Handling
 
 The generated JS wrappers automatically handle errors by passing an error
@@ -57,19 +63,6 @@ Wrappers of functions declared `throws` raise the declaring module's typed
 error class (a `WeaveFFIError` subclass with a per-code subclass, such as
 `KeyNotFound`); every other wrapper raises the generic `WeaveFFIError` only
 for producer panics and marshalling failures.
-
-## Unsupported Features
-
-This IDL uses features the wasm target does not support (generated because
-`allow_unsupported` is set). Single-threaded `wasm32-unknown-unknown` has no
-producer thread to deliver events from, so:
-
-- **callbacks**: events.OnMessage
-- **listeners**: events.message_listener
-
-The TypeScript declarations omit these entry points; the JS module exposes
-explicit stubs that throw on call. Use a native target (node, python, …) when
-you need them.
 
 ## API Reference
 

--- a/crates/weaveffi-cli/tests/snapshots/wasm_events__weaveffi_wasm_d_ts.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_events__weaveffi_wasm_d_ts.snap
@@ -29,6 +29,14 @@ export interface WeaveffiWasmModule {
      * @throws {WeaveFFIError} if the native call fails
      */
     getMessages(): IterableIterator<string>;
+    /**
+     * Register a listener for the `OnMessage` callback.
+     *
+     * @returns A subscription id for `unregisterMessageListener()`.
+     */
+    registerMessageListener(callback: (message: string) => void): number;
+    /** Unregister a listener previously registered with `registerMessageListener()`. */
+    unregisterMessageListener(id: number): void;
   };
 }
 

--- a/crates/weaveffi-cli/tests/snapshots/wasm_events__weaveffi_wasm_js.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_events__weaveffi_wasm_js.snap
@@ -157,6 +157,15 @@ class _WeaveFFIIterator {
   }
 }
 
+function _registerTrampoline(table, paramTypes, handler) {
+  const idx = table.grow(1);
+  table.set(idx, new WebAssembly.Function(
+    { parameters: paramTypes, results: [] },
+    handler
+  ));
+  return idx;
+}
+
 /**
  * Load a WeaveFFI Wasm module from the given URL.
  *
@@ -192,6 +201,21 @@ export async function loadWeaveffiWasm(url) {
   const { instance } = await WebAssembly.instantiate(bytes, {});
   const wasm = instance.exports;
 
+  const _table = wasm.__indirect_function_table;
+
+  // Listener subscriptions, keyed by the context id the loader
+  // threads through the C ABI's void* context slot. Each entry
+  // holds the JS callback and the producer's subscription id.
+  let _nextLsnId = 1;
+  const _listeners = new Map();
+
+  const _lsnPtr_weaveffi_events_OnMessage_fn = _registerTrampoline(_table, ['i32', 'i32'], (a0, _ctx) => {
+    const _l = _listeners.get(_ctx);
+    if (_l === undefined) return;
+    const _p0 = _readCStr(wasm, a0);
+    _l.callback(_p0);
+  });
+
   return {
     _raw: wasm,
     events: {
@@ -213,11 +237,17 @@ export async function loadWeaveffiWasm(url) {
           (it) => wasm.weaveffi_events_GetMessagesIterator_destroy(it),
           _checkErr, (w, p) => _takeCStr(w, new DataView(w.memory.buffer).getUint32(p, true)));
       },
-      registerMessageListener() {
-        throw new Error("weaveffi: listener 'message_listener' is not supported by the wasm target (single-threaded wasm has no producer thread to deliver events); use a native target for listeners");
+      registerMessageListener(callback) {
+        const _id = _nextLsnId++;
+        const _rid = wasm.weaveffi_events_register_message_listener(_lsnPtr_weaveffi_events_OnMessage_fn, _id);
+        _listeners.set(_id, { callback, rid: _rid });
+        return _id;
       },
-      unregisterMessageListener() {
-        throw new Error("weaveffi: listener 'message_listener' is not supported by the wasm target (single-threaded wasm has no producer thread to deliver events); use a native target for listeners");
+      unregisterMessageListener(id) {
+        const _l = _listeners.get(id);
+        if (_l === undefined) return;
+        _listeners.delete(id);
+        wasm.weaveffi_events_unregister_message_listener(_l.rid);
       },
     },
   };

--- a/crates/weaveffi-cli/tests/snapshots/wasm_kitchen_sink__README_md.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_kitchen_sink__README_md.snap
@@ -41,6 +41,12 @@ Lists are passed as a **pointer + length** pair (`i32` pointer, `i32` length) re
 
 `iter<T>` functions return a **lazy JS iterator** (typed `IterableIterator<T>`): each `next()` issues exactly one producer call, so iteration streams in constant memory. The producer handle is destroyed exactly once, on exhaustion or via `return()` when iteration stops early (a `for...of` loop calls `return()` automatically on `break` or `throw`). Abandoning an iterator without exhausting or closing it leaks the handle.
 
+### Callbacks and Listeners
+
+Each listener surfaces as a `register.../unregister...` pair. `register` takes a plain JS function and returns a numeric subscription id; `unregister` takes that id and stops delivery. Delivery is **synchronous and same-thread**: `wasm32-unknown-unknown` is single-threaded, so events fire only while a call into the module is on the stack (for example, a producer function that emits during its own execution). A producer that emits from a spawned thread cannot run on this target at all.
+
+Callback arguments are **borrowed for the duration of the callback**: strings and byte buffers are copied into JS values before your function runs, but struct, rich-enum, and interface arguments wrap producer-owned memory. Read what you need inside the callback and do not retain the wrapper or call `free()` on it.
+
 ### Error Handling
 
 The generated JS wrappers automatically handle errors by passing an error
@@ -57,19 +63,6 @@ Wrappers of functions declared `throws` raise the declaring module's typed
 error class (a `WeaveFFIError` subclass with a per-code subclass, such as
 `KeyNotFound`); every other wrapper raises the generic `WeaveFFIError` only
 for producer panics and marshalling failures.
-
-## Unsupported Features
-
-This IDL uses features the wasm target does not support (generated because
-`allow_unsupported` is set). Single-threaded `wasm32-unknown-unknown` has no
-producer thread to deliver events from, so:
-
-- **callbacks**: kitchen.OnReady
-- **listeners**: kitchen.ready_listener
-
-The TypeScript declarations omit these entry points; the JS module exposes
-explicit stubs that throw on call. Use a native target (node, python, …) when
-you need them.
 
 ## API Reference
 

--- a/crates/weaveffi-cli/tests/snapshots/wasm_kitchen_sink__weaveffi_wasm_d_ts.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_kitchen_sink__weaveffi_wasm_d_ts.snap
@@ -207,6 +207,14 @@ export interface WeaveffiWasmModule {
      * @throws {WeaveFFIError} if the native call fails
      */
     newOp(): number;
+    /**
+     * Subscribe to OnReady events
+     *
+     * @returns A subscription id for `unregisterReadyListener()`.
+     */
+    registerReadyListener(callback: (code: number, msg: string) => void): number;
+    /** Unregister a listener previously registered with `registerReadyListener()`. */
+    unregisterReadyListener(id: number): void;
     Gadget: typeof Gadget;
     nested: {
       /**

--- a/crates/weaveffi-cli/tests/snapshots/wasm_kitchen_sink__weaveffi_wasm_js.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_kitchen_sink__weaveffi_wasm_js.snap
@@ -604,9 +604,10 @@ export async function loadWeaveffiWasm(url) {
   const { instance } = await WebAssembly.instantiate(bytes, {});
   const wasm = instance.exports;
 
+  const _table = wasm.__indirect_function_table;
+
   let _nextCtxId = 1;
   const _asyncContexts = new Map();
-  const _table = wasm.__indirect_function_table;
 
   function _asyncHandler(ctxId, errPtr, ...results) {
     const ctx = _asyncContexts.get(ctxId);
@@ -621,6 +622,20 @@ export async function loadWeaveffiWasm(url) {
   }
 
   const _cbPtr_i32_i32_i32 = _registerTrampoline(_table, ['i32', 'i32', 'i32'], _asyncHandler);
+
+  // Listener subscriptions, keyed by the context id the loader
+  // threads through the C ABI's void* context slot. Each entry
+  // holds the JS callback and the producer's subscription id.
+  let _nextLsnId = 1;
+  const _listeners = new Map();
+
+  const _lsnPtr_weaveffi_kitchen_OnReady_fn = _registerTrampoline(_table, ['i32', 'i32', 'i32'], (a0, a1, _ctx) => {
+    const _l = _listeners.get(_ctx);
+    if (_l === undefined) return;
+    const _p0 = a0;
+    const _p1 = _readCStr(wasm, a1);
+    _l.callback(_p0, _p1);
+  });
 
   // A pocket-sized interface exercising the object surface
   class Gadget {
@@ -874,11 +889,18 @@ export async function loadWeaveffiWasm(url) {
         _freeErr(wasm, _err);
         return _r;
       },
-      registerReadyListener() {
-        throw new Error("weaveffi: listener 'ready_listener' is not supported by the wasm target (single-threaded wasm has no producer thread to deliver events); use a native target for listeners");
+      /** Subscribe to OnReady events */
+      registerReadyListener(callback) {
+        const _id = _nextLsnId++;
+        const _rid = wasm.weaveffi_kitchen_register_ready_listener(_lsnPtr_weaveffi_kitchen_OnReady_fn, _id);
+        _listeners.set(_id, { callback, rid: _rid });
+        return _id;
       },
-      unregisterReadyListener() {
-        throw new Error("weaveffi: listener 'ready_listener' is not supported by the wasm target (single-threaded wasm has no producer thread to deliver events); use a native target for listeners");
+      unregisterReadyListener(id) {
+        const _l = _listeners.get(id);
+        if (_l === undefined) return;
+        _listeners.delete(id);
+        wasm.weaveffi_kitchen_unregister_ready_listener(_l.rid);
       },
       Gadget: Gadget,
       Item: {

--- a/crates/weaveffi-cli/tests/snapshots/wasm_kvstore__README_md.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_kvstore__README_md.snap
@@ -41,6 +41,12 @@ Lists are passed as a **pointer + length** pair (`i32` pointer, `i32` length) re
 
 `iter<T>` functions return a **lazy JS iterator** (typed `IterableIterator<T>`): each `next()` issues exactly one producer call, so iteration streams in constant memory. The producer handle is destroyed exactly once, on exhaustion or via `return()` when iteration stops early (a `for...of` loop calls `return()` automatically on `break` or `throw`). Abandoning an iterator without exhausting or closing it leaks the handle.
 
+### Callbacks and Listeners
+
+Each listener surfaces as a `register.../unregister...` pair. `register` takes a plain JS function and returns a numeric subscription id; `unregister` takes that id and stops delivery. Delivery is **synchronous and same-thread**: `wasm32-unknown-unknown` is single-threaded, so events fire only while a call into the module is on the stack (for example, a producer function that emits during its own execution). A producer that emits from a spawned thread cannot run on this target at all.
+
+Callback arguments are **borrowed for the duration of the callback**: strings and byte buffers are copied into JS values before your function runs, but struct, rich-enum, and interface arguments wrap producer-owned memory. Read what you need inside the callback and do not retain the wrapper or call `free()` on it.
+
 ### Error Handling
 
 The generated JS wrappers automatically handle errors by passing an error
@@ -57,19 +63,6 @@ Wrappers of functions declared `throws` raise the declaring module's typed
 error class (a `WeaveFFIError` subclass with a per-code subclass, such as
 `KeyNotFound`); every other wrapper raises the generic `WeaveFFIError` only
 for producer panics and marshalling failures.
-
-## Unsupported Features
-
-This IDL uses features the wasm target does not support (generated because
-`allow_unsupported` is set). Single-threaded `wasm32-unknown-unknown` has no
-producer thread to deliver events from, so:
-
-- **callbacks**: kv.OnEvict
-- **listeners**: kv.eviction_listener
-
-The TypeScript declarations omit these entry points; the JS module exposes
-explicit stubs that throw on call. Use a native target (node, python, …) when
-you need them.
 
 ## API Reference
 

--- a/crates/weaveffi-cli/tests/snapshots/wasm_kvstore__weaveffi_wasm_d_ts.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_kvstore__weaveffi_wasm_d_ts.snap
@@ -150,6 +150,14 @@ export interface Stats {
 export interface WeaveffiWasmModule {
   _raw: WebAssembly.Exports;
   kv: {
+    /**
+     * Subscribe to per-key eviction notifications
+     *
+     * @returns A subscription id for `unregisterEvictionListener()`.
+     */
+    registerEvictionListener(callback: (key: string) => void): number;
+    /** Unregister a listener previously registered with `registerEvictionListener()`. */
+    unregisterEvictionListener(id: number): void;
     Store: typeof Store;
     stats: {
       /**

--- a/crates/weaveffi-cli/tests/snapshots/wasm_kvstore__weaveffi_wasm_js.snap
+++ b/crates/weaveffi-cli/tests/snapshots/wasm_kvstore__weaveffi_wasm_js.snap
@@ -577,9 +577,10 @@ export async function loadWeaveffiWasm(url) {
   const { instance } = await WebAssembly.instantiate(bytes, {});
   const wasm = instance.exports;
 
+  const _table = wasm.__indirect_function_table;
+
   let _nextCtxId = 1;
   const _asyncContexts = new Map();
-  const _table = wasm.__indirect_function_table;
 
   function _asyncHandler(ctxId, errPtr, ...results) {
     const ctx = _asyncContexts.get(ctxId);
@@ -594,6 +595,19 @@ export async function loadWeaveffiWasm(url) {
   }
 
   const _cbPtr_i32_i32_i64 = _registerTrampoline(_table, ['i32', 'i32', 'i64'], _asyncHandler);
+
+  // Listener subscriptions, keyed by the context id the loader
+  // threads through the C ABI's void* context slot. Each entry
+  // holds the JS callback and the producer's subscription id.
+  let _nextLsnId = 1;
+  const _listeners = new Map();
+
+  const _lsnPtr_weaveffi_kv_OnEvict_fn = _registerTrampoline(_table, ['i32', 'i32'], (a0, _ctx) => {
+    const _l = _listeners.get(_ctx);
+    if (_l === undefined) return;
+    const _p0 = _readCStr(wasm, a0);
+    _l.callback(_p0);
+  });
 
   // An in-memory key-value store owning its entries; destroying the object releases all of its state
   class Store {
@@ -710,11 +724,18 @@ export async function loadWeaveffiWasm(url) {
   return {
     _raw: wasm,
     kv: {
-      registerEvictionListener() {
-        throw new Error("weaveffi: listener 'eviction_listener' is not supported by the wasm target (single-threaded wasm has no producer thread to deliver events); use a native target for listeners");
+      /** Subscribe to per-key eviction notifications */
+      registerEvictionListener(callback) {
+        const _id = _nextLsnId++;
+        const _rid = wasm.weaveffi_kv_register_eviction_listener(_lsnPtr_weaveffi_kv_OnEvict_fn, _id);
+        _listeners.set(_id, { callback, rid: _rid });
+        return _id;
       },
-      unregisterEvictionListener() {
-        throw new Error("weaveffi: listener 'eviction_listener' is not supported by the wasm target (single-threaded wasm has no producer thread to deliver events); use a native target for listeners");
+      unregisterEvictionListener(id) {
+        const _l = _listeners.get(id);
+        if (_l === undefined) return;
+        _listeners.delete(id);
+        wasm.weaveffi_kv_unregister_eviction_listener(_l.rid);
       },
       Store: Store,
       Entry: {

--- a/crates/weaveffi-core/src/codegen/mod.rs
+++ b/crates/weaveffi-core/src/codegen/mod.rs
@@ -67,8 +67,8 @@ pub trait Generator: Send + Sync {
     fn capabilities(&self) -> TargetCapabilities;
 
     /// Whether the user explicitly opted in to generating this target even
-    /// though the API uses features the target does not support (for example
-    /// `generators.wasm.allow_unsupported: true`). When `true` the
+    /// though the API uses features the target does not support (via an
+    /// `allow_unsupported: true` flag in the target's config). When `true` the
     /// orchestrator downgrades the capability failure to a loud warning and
     /// the generator must emit an explicit unsupported surface (throwing
     /// stubs, documentation) rather than silently omitting the feature.

--- a/crates/weaveffi-gen-wasm/src/lib.rs
+++ b/crates/weaveffi-gen-wasm/src/lib.rs
@@ -16,16 +16,17 @@ use camino::Utf8Path;
 use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToUpperCamelCase};
 use serde::{Deserialize, Serialize};
 use weaveffi_core::backend::{LanguageBackend, OutputFile};
-use weaveffi_core::capabilities::{self, TargetCapabilities};
+use weaveffi_core::abi::CType;
+use weaveffi_core::capabilities::TargetCapabilities;
 use weaveffi_core::codegen::common::{
     emit_doc as common_emit_doc, walk_modules, walk_modules_with_path, DocCommentStyle,
 };
 use weaveffi_core::codegen::CodeWriter;
 use weaveffi_core::errors::ERROR_BRAND;
 use weaveffi_core::model::{
-    BindingModel, CallShape, EnumBinding, ErrorBinding, FieldBinding, FnBinding, InterfaceBinding,
-    IteratorBinding, ListenerBinding, ModuleBinding, ParamBinding, RichEnumBinding,
-    RichVariantBinding, StructBinding,
+    BindingModel, CallShape, CallbackBinding, EnumBinding, ErrorBinding, FieldBinding, FnBinding,
+    InterfaceBinding, IteratorBinding, ListenerBinding, ModuleBinding, ParamBinding,
+    RichEnumBinding, RichVariantBinding, StructBinding,
 };
 use weaveffi_core::pkg::{self, ResolvedPackage};
 use weaveffi_core::plan::ErrorStrategy;
@@ -52,19 +53,14 @@ pub struct WasmConfig {
     /// via `[global] c_prefix`; honored so the wasm glue calls the same
     /// exported symbols the producer emits.
     pub prefix: Option<String>,
-    /// Opt in to generating wasm bindings for an IDL that uses features the
-    /// wasm target does not support (callbacks and listeners). The supported
-    /// surface is generated normally; each unsupported entry point becomes an
-    /// explicit stub that throws at call time, and the orchestrator prints a
-    /// warning listing what was skipped. Without this flag, generation fails.
-    pub allow_unsupported: bool,
     /// Target an Emscripten build instead of a bare `wasm32-unknown-unknown`
     /// one. The loader then accepts a pre-initialized Emscripten `Module`
     /// object (or the promise returned by its `MODULARIZE` factory) instead
     /// of a `.wasm` URL, and binds the module's underscore-prefixed exports
-    /// to the symbol names the glue calls. Async functions are not supported
-    /// in this mode; each one becomes an explicit stub that throws at call
-    /// time and is omitted from the TypeScript declarations.
+    /// to the symbol names the glue calls. Async functions, callbacks, and
+    /// listeners are not supported in this mode; each one becomes an explicit
+    /// stub that throws at call time and is omitted from the TypeScript
+    /// declarations.
     pub emscripten: bool,
     /// Basename of the IDL the CLI was invoked with.
     #[serde(skip)]
@@ -98,26 +94,18 @@ impl LanguageBackend for WasmGenerator {
         "wasm"
     }
 
-    /// Callbacks and listeners are not supported. Async completion works
-    /// because each call registers a single-shot trampoline in the wasm
-    /// function table that the producer invokes before the launcher returns
-    /// control; module callbacks/listeners are long-lived and producer-
-    /// initiated (typically from worker threads), and single-threaded
-    /// `wasm32-unknown-unknown` has no thread to deliver them from. Rather
-    /// than pretend (the pre-capability generator silently dropped both),
-    /// declare them unsupported; `allow_unsupported: true` opts in to
-    /// generating the supported surface with explicit throwing stubs.
+    /// Every gated feature is supported. Callbacks and listeners share the
+    /// async machinery: the loader installs one long-lived trampoline per
+    /// callback typedef in the wasm function table and hands its index to the
+    /// producer's `register_*` symbol, so `emit_*` dispatches straight back
+    /// into JavaScript. Because `wasm32-unknown-unknown` is single-threaded,
+    /// delivery is always synchronous: events fire only while a call into the
+    /// module is on the stack (a producer that emits from a spawned thread
+    /// cannot run on this target at all). Emscripten mode emits explicit
+    /// throwing stubs for callbacks, listeners, and async functions instead;
+    /// see [`WasmConfig::emscripten`].
     fn capabilities(&self) -> TargetCapabilities {
-        TargetCapabilities {
-            async_functions: true,
-            callbacks: false,
-            listeners: false,
-            iterators: true,
-        }
-    }
-
-    fn allows_unsupported(&self, config: &Self::Config) -> bool {
-        config.allow_unsupported
+        TargetCapabilities::full()
     }
 
     fn prefix<'a>(&self, config: &'a Self::Config) -> &'a str {
@@ -351,6 +339,18 @@ fn render_wasm_readme(
                  them.\n\n",
             );
         }
+        if walk_modules(&api.modules).any(|m| !m.listeners.is_empty()) {
+            out.push_str("## Callbacks and Listeners\n\n");
+            out.push_str(
+                "Callbacks and listeners are not supported in Emscripten mode: their \
+                 trampolines rely on `WebAssembly.Function` and a growable \
+                 `__indirect_function_table`, neither of which an Emscripten module \
+                 exposes portably. Each register/unregister entry point is generated \
+                 as an explicit stub that throws at call time and is omitted from the \
+                 TypeScript declarations. Use the standard `wasm32-unknown-unknown` \
+                 loader or a native target when you need them.\n\n",
+            );
+        }
     } else {
         out.push_str("This folder contains a minimal stub to help you load a `wasm32-unknown-unknown` build of your WeaveFFI library.\n\n");
         out.push_str("Build (example):\n\n");
@@ -391,6 +391,25 @@ fn render_wasm_readme(
     out.push_str("exactly once, on exhaustion or via `return()` when iteration stops early ");
     out.push_str("(a `for...of` loop calls `return()` automatically on `break` or `throw`). ");
     out.push_str("Abandoning an iterator without exhausting or closing it leaks the handle.\n");
+    if !emscripten && walk_modules(&api.modules).any(|m| !m.listeners.is_empty()) {
+        out.push_str("\n### Callbacks and Listeners\n\n");
+        out.push_str(
+            "Each listener surfaces as a `register.../unregister...` pair. `register` \
+             takes a plain JS function and returns a numeric subscription id; \
+             `unregister` takes that id and stops delivery. Delivery is **synchronous \
+             and same-thread**: `wasm32-unknown-unknown` is single-threaded, so events \
+             fire only while a call into the module is on the stack (for example, a \
+             producer function that emits during its own execution). A producer that \
+             emits from a spawned thread cannot run on this target at all.\n\n",
+        );
+        out.push_str(
+            "Callback arguments are **borrowed for the duration of the callback**: \
+             strings and byte buffers are copied into JS values before your function \
+             runs, but struct, rich-enum, and interface arguments wrap producer-owned \
+             memory. Read what you need inside the callback and do not retain the \
+             wrapper or call `free()` on it.\n",
+        );
+    }
     out.push_str("\n### Error Handling\n\n");
     out.push_str("The generated JS wrappers automatically handle errors by passing an error\n");
     out.push_str("pointer as the last argument to each Wasm function. Your Wasm module must\n");
@@ -405,8 +424,6 @@ fn render_wasm_readme(
     out.push_str("`KeyNotFound`); every other wrapper raises the generic `WeaveFFIError` only\n");
     out.push_str("for producer panics and marshalling failures.\n");
 
-    render_unsupported_section(&mut out, api);
-
     if !api.modules.is_empty() {
         render_api_reference(&mut out, api, model);
     }
@@ -414,35 +431,6 @@ fn render_wasm_readme(
     out.push('\n');
     out.push_str(&render_trailer(CommentStyle::Xml, "README.md"));
     out
-}
-
-/// When the IDL uses features the wasm target does not support (callbacks,
-/// listeners; generation only proceeds under `allow_unsupported`), document
-/// exactly what is missing and how it behaves, listing each declaration.
-fn render_unsupported_section(out: &mut String, api: &Api) {
-    let used = capabilities::used_features(api);
-    let caps = LanguageBackend::capabilities(&WasmGenerator);
-    let unsupported: Vec<_> = used
-        .iter()
-        .filter(|(feature, _)| !caps.supports(**feature))
-        .collect();
-    if unsupported.is_empty() {
-        return;
-    }
-    out.push_str("\n## Unsupported Features\n\n");
-    out.push_str(
-        "This IDL uses features the wasm target does not support (generated because\n\
-         `allow_unsupported` is set). Single-threaded `wasm32-unknown-unknown` has no\n\
-         producer thread to deliver events from, so:\n\n",
-    );
-    for (feature, locations) in unsupported {
-        out.push_str(&format!("- **{feature}**: {}\n", locations.join(", ")));
-    }
-    out.push_str(
-        "\nThe TypeScript declarations omit these entry points; the JS module exposes\n\
-         explicit stubs that throw on call. Use a native target (node, python, …) when\n\
-         you need them.\n",
-    );
 }
 
 fn render_api_reference(out: &mut String, api: &Api, model: &BindingModel) {
@@ -694,21 +682,27 @@ fn async_ret_has_string_buffers(ret: Option<&TypeRef>) -> bool {
     }
 }
 
+/// Whether `ty` or any type nested inside it (optional payloads, list and
+/// iterator elements, map keys/values) satisfies `pred`.
+fn typeref_deep_any(ty: &TypeRef, pred: &dyn Fn(&TypeRef) -> bool) -> bool {
+    if pred(ty) {
+        return true;
+    }
+    match ty {
+        TypeRef::Optional(inner) | TypeRef::List(inner) | TypeRef::Iterator(inner) => {
+            typeref_deep_any(inner, pred)
+        }
+        TypeRef::Map(k, v) => typeref_deep_any(k, pred) || typeref_deep_any(v, pred),
+        _ => false,
+    }
+}
+
 /// Visit every boundary-crossing type in `api` (function params + returns and
 /// struct field types), recursing into composite types, and return whether any
 /// satisfies `pred`.
 fn api_deep_any(api: &Api, pred: &dyn Fn(&TypeRef) -> bool) -> bool {
     fn deep(ty: &TypeRef, pred: &dyn Fn(&TypeRef) -> bool) -> bool {
-        if pred(ty) {
-            return true;
-        }
-        match ty {
-            TypeRef::Optional(inner) | TypeRef::List(inner) | TypeRef::Iterator(inner) => {
-                deep(inner, pred)
-            }
-            TypeRef::Map(k, v) => deep(k, pred) || deep(v, pred),
-            _ => false,
-        }
+        typeref_deep_any(ty, pred)
     }
     fn fn_any(f: &weaveffi_ir::ir::Function, pred: &dyn Fn(&TypeRef) -> bool) -> bool {
         f.params.iter().any(|p| deep(&p.ty, pred))
@@ -1710,16 +1704,27 @@ fn render_dts_module_interface(
     indent: &str,
     emscripten: bool,
 ) {
-    fn tree_has_content(m: &Module, path: &str, by_path: &HashMap<&str, &ModuleBinding>) -> bool {
-        let here = by_path
-            .get(path)
-            .is_some_and(|mb| !mb.functions.is_empty() || !mb.interfaces.is_empty());
-        here || m
-            .modules
-            .iter()
-            .any(|sub| tree_has_content(sub, &format!("{path}_{}", sub.name), by_path))
+    fn tree_has_content(
+        m: &Module,
+        path: &str,
+        by_path: &HashMap<&str, &ModuleBinding>,
+        include_listeners: bool,
+    ) -> bool {
+        let here = by_path.get(path).is_some_and(|mb| {
+            !mb.functions.is_empty()
+                || !mb.interfaces.is_empty()
+                || (include_listeners && !mb.listeners.is_empty())
+        });
+        here || m.modules.iter().any(|sub| {
+            tree_has_content(
+                sub,
+                &format!("{path}_{}", sub.name),
+                by_path,
+                include_listeners,
+            )
+        })
     }
-    if !tree_has_content(m, module_path, by_path) {
+    if !tree_has_content(m, module_path, by_path, !emscripten) {
         return;
     }
     let mb = by_path[module_path];
@@ -1743,6 +1748,15 @@ fn render_dts_module_interface(
                 dts_ret(f)
             ));
         }
+        // Listeners are throwing stubs in Emscripten mode; omitting them here
+        // makes the gap a compile-time error for TS consumers.
+        if !emscripten {
+            for l in &mb.listeners {
+                let mut tmp = String::new();
+                render_dts_listener(&mut tmp, mb, l, &inner);
+                w.raw(tmp);
+            }
+        }
         // The module object carries the interface class itself, so statics,
         // factories, and `new` are reachable as `api.kv.Store...`.
         for i in &mb.interfaces {
@@ -1755,6 +1769,55 @@ fn render_dts_module_interface(
             w.raw(tmp);
         }
     });
+    out.push_str(&w.finish());
+}
+
+/// Emit the TypeScript declarations for one listener's register/unregister
+/// pair. The callback parameter types come from the referenced callback
+/// typedef; the subscription id is a plain `number` (the loader keys
+/// subscriptions by its own context id, so the producer's `uint64_t` id never
+/// reaches the public surface).
+fn render_dts_listener(out: &mut String, mb: &ModuleBinding, l: &ListenerBinding, indent: &str) {
+    let Some(cb) = mb.callback(&l.event_callback) else {
+        // Validation guarantees the referenced callback exists in-module.
+        unreachable!("listener '{}' references unknown callback", l.name);
+    };
+    let register_name = format!("register_{}", l.name).to_lower_camel_case();
+    let unregister_name = format!("unregister_{}", l.name).to_lower_camel_case();
+    let cb_params: Vec<String> = cb
+        .params
+        .iter()
+        .map(|p| format!("{}: {}", js_param_name(p), ts_type_for(&p.ty)))
+        .collect();
+    let mut w = CodeWriter::two_space().with_depth(indent.len() / 2);
+    let register_doc = match &l.doc {
+        Some(d) => format!(
+            "{}\n\n@returns A subscription id for `{unregister_name}()`.",
+            d.trim()
+        ),
+        None => format!(
+            "Register a listener for the `{}` callback.\n\n@returns A \
+             subscription id for `{unregister_name}()`.",
+            cb.name
+        ),
+    };
+    let mut doc = String::new();
+    emit_doc(&mut doc, &Some(register_doc), indent);
+    w.raw(doc);
+    w.line(format!(
+        "{register_name}(callback: ({}) => void): number;",
+        cb_params.join(", ")
+    ));
+    let mut doc = String::new();
+    emit_doc(
+        &mut doc,
+        &Some(format!(
+            "Unregister a listener previously registered with `{register_name}()`."
+        )),
+        indent,
+    );
+    w.raw(doc);
+    w.line(format!("{unregister_name}(id: number): void;"));
     out.push_str(&w.finish());
 }
 
@@ -2093,6 +2156,14 @@ fn render_wasm_js_stub(
             .iter()
             .flat_map(ModuleBinding::callables)
             .any(|f| f.is_async);
+    // Listeners get real dispatch only in the standard loader; Emscripten
+    // mode emits throwing stubs, so no trampolines or registry there either.
+    let listener_cbs: Vec<&CallbackBinding> = if emscripten {
+        Vec::new()
+    } else {
+        collect_listener_callbacks(model)
+    };
+    let has_listeners = !listener_cbs.is_empty();
     // Opaque-object wrappers (structs and rich/algebraic enums) construct via a
     // fallible `*_new`/`*_create` that threads an `out_err`, so they need the
     // error helpers even in a module that declares no free functions.
@@ -2103,7 +2174,15 @@ fn render_wasm_js_stub(
     let needs_err = has_functions || has_opaque;
     // Error messages always cross as C strings, so anything needing the error
     // helpers also needs the string-read helpers regardless of declared types.
-    let needs_strings = needs_err || api_deep_any(api, &|t| is_string_type(t));
+    // Listener callback arguments arrive as borrowed C strings read through
+    // the same helper, so their parameter types count too.
+    let needs_strings = needs_err
+        || api_deep_any(api, &|t| is_string_type(t))
+        || listener_cbs.iter().any(|cb| {
+            cb.params
+                .iter()
+                .any(|p| typeref_deep_any(&p.ty, &is_string_type))
+        });
     let needs_bytes = api_deep_any(api, &|t| {
         matches!(t, TypeRef::Bytes | TypeRef::BorrowedBytes)
     });
@@ -2121,15 +2200,21 @@ fn render_wasm_js_stub(
         TypeRef::Iterator(inner) => is_string_type(inner),
         _ => false,
     });
-    // Async list/map results arrive borrowed: their string elements are read
-    // without freeing, through a separate helper.
-    let needs_borrowed_str_array = has_async
+    // Async list/map results and listener callback arguments arrive borrowed:
+    // their string elements are read without freeing, through a separate
+    // helper.
+    let needs_borrowed_str_array = (has_async
         && model
             .modules
             .iter()
             .flat_map(ModuleBinding::callables)
             .filter(|f| f.is_async)
-            .any(|f| async_ret_has_string_buffers(f.ret.as_ref()));
+            .any(|f| async_ret_has_string_buffers(f.ret.as_ref())))
+        || listener_cbs.iter().any(|cb| {
+            cb.params
+                .iter()
+                .any(|p| async_ret_has_string_buffers(Some(&p.ty)))
+        });
     // Any iterator-returning callable pulls in the shared lazy-iterator
     // wrapper class.
     let has_iterators = model
@@ -2345,7 +2430,7 @@ fn render_wasm_js_stub(
         out.push_str("}\n\n");
     }
 
-    if has_async {
+    if has_async || has_listeners {
         out.push_str("function _registerTrampoline(table, paramTypes, handler) {\n");
         out.push_str("  const idx = table.grow(1);\n");
         out.push_str("  table.set(idx, new WebAssembly.Function(\n");
@@ -2502,10 +2587,13 @@ fn render_wasm_js_stub(
             out.push_str("  const wasm = instance.exports;\n\n");
         }
 
+        if has_async || has_listeners {
+            out.push_str("  const _table = wasm.__indirect_function_table;\n\n");
+        }
+
         if has_async {
             out.push_str("  let _nextCtxId = 1;\n");
-            out.push_str("  const _asyncContexts = new Map();\n");
-            out.push_str("  const _table = wasm.__indirect_function_table;\n\n");
+            out.push_str("  const _asyncContexts = new Map();\n\n");
             out.push_str("  function _asyncHandler(ctxId, errPtr, ...results) {\n");
             out.push_str("    const ctx = _asyncContexts.get(ctxId);\n");
             out.push_str("    if (!ctx) return;\n");
@@ -2536,6 +2624,18 @@ fn render_wasm_js_stub(
                     "  const _cbPtr_{sig_key} = _registerTrampoline(_table, [{}], _asyncHandler);\n",
                     params_js.join(", ")
                 ));
+            }
+            out.push('\n');
+        }
+
+        if has_listeners {
+            out.push_str("  // Listener subscriptions, keyed by the context id the loader\n");
+            out.push_str("  // threads through the C ABI's void* context slot. Each entry\n");
+            out.push_str("  // holds the JS callback and the producer's subscription id.\n");
+            out.push_str("  let _nextLsnId = 1;\n");
+            out.push_str("  const _listeners = new Map();\n\n");
+            for cb in &listener_cbs {
+                emit_js_listener_trampoline(&mut out, cb, "  ");
             }
             out.push('\n');
         }
@@ -2605,7 +2705,11 @@ fn render_js_module_object(
         }
         for l in &mb.listeners {
             let mut tmp = String::new();
-            emit_js_listener_stub(&mut tmp, l, &inner);
+            if emscripten {
+                emit_js_listener_stub(&mut tmp, l, &inner);
+            } else {
+                emit_js_listener_api(&mut tmp, l, &inner);
+            }
             w.raw(tmp);
         }
         // The interface class itself is exposed on the module object, so
@@ -2684,24 +2788,266 @@ fn emit_js_async_stub(out: &mut String, f: &FnBinding, decl: JsDecl, indent: &st
     out.push_str(&w.finish());
 }
 
-/// Listeners are unsupported on wasm (see `WasmGenerator::capabilities`);
-/// generation only reaches here when `allow_unsupported` is set. Each
-/// register/unregister entry point becomes an explicit stub that throws at
-/// call time, so the gap is impossible to miss from JS even though the
-/// `.d.ts` deliberately omits the pair (a compile-time error for TS users).
+/// Listeners are unsupported in Emscripten mode: their trampolines rely on
+/// `WebAssembly.Function` and a growable `__indirect_function_table`, exactly
+/// like the async machinery. Each register/unregister entry point becomes an
+/// explicit stub that throws at call time, so the gap is impossible to miss
+/// from JS even though the `.d.ts` deliberately omits the pair (a
+/// compile-time error for TS users).
 fn emit_js_listener_stub(out: &mut String, l: &ListenerBinding, indent: &str) {
     let mut w = CodeWriter::two_space().with_depth(indent.len() / 2);
     for op in ["register", "unregister"] {
         let name = format!("{op}_{}", l.name).to_lower_camel_case();
         w.block(format!("{name}() {{"), "},", |w| {
             w.line(format!(
-                "throw new Error(\"weaveffi: listener '{}' is not supported by the wasm \
-                 target (single-threaded wasm has no producer thread to deliver events); use a \
-                 native target for listeners\");",
+                "throw new Error(\"weaveffi: listener '{}' is not supported in \
+                 Emscripten mode; use the wasm32-unknown-unknown loader or a native \
+                 target\");",
                 l.name
             ));
         });
     }
+    out.push_str(&w.finish());
+}
+
+/// Every callback typedef referenced by at least one listener, deduplicated
+/// by `c_fn_type` in declaration order. Each gets one long-lived trampoline
+/// in the wasm function table, shared by all of its subscriptions (the
+/// per-subscription context id disambiguates), so register/unregister churn
+/// never grows the table.
+fn collect_listener_callbacks(model: &BindingModel) -> Vec<&CallbackBinding> {
+    let mut cbs: Vec<&CallbackBinding> = Vec::new();
+    for m in &model.modules {
+        for l in &m.listeners {
+            let Some(cb) = m.callback(&l.event_callback) else {
+                // Validation guarantees the referenced callback exists
+                // in-module.
+                unreachable!("listener '{}' references unknown callback", l.name);
+            };
+            if !cbs.iter().any(|c| c.c_fn_type == cb.c_fn_type) {
+                cbs.push(cb);
+            }
+        }
+    }
+    cbs
+}
+
+/// The wasm value type of one C ABI slot: pointers and 32-bit-or-smaller
+/// scalars are `i32` on wasm32, 64-bit integers and handles widen to `i64`,
+/// and floats keep their width.
+fn cb_slot_wasm_type(ty: &CType) -> &'static str {
+    match ty {
+        CType::Int64 | CType::Uint64 | CType::Handle => "i64",
+        CType::Float => "f32",
+        CType::Double => "f64",
+        _ => "i32",
+    }
+}
+
+/// The JS-side name of the long-lived trampoline registered for one callback
+/// typedef. `c_fn_type` is a C identifier, so it is a valid JS identifier
+/// suffix.
+fn js_listener_tramp_name(c_fn_type: &str) -> String {
+    format!("_lsnPtr_{c_fn_type}")
+}
+
+/// Emit `const {target} = ...;` decoding one callback argument from its raw
+/// wasm slot values into the idiomatic JS value the subscriber sees.
+///
+/// The producer owns every argument for the duration of the dispatch (the
+/// `emit_*` helper frees lowered payloads after the last subscriber returns),
+/// so this is the borrowing side of the marshalling table: strings and byte
+/// buffers are copied out of linear memory and never freed here, and opaque
+/// pointers (records, rich enums, interfaces) are wrapped without taking
+/// ownership.
+fn emit_cb_param_decode(out: &mut String, indent: &str, ty: &TypeRef, slots: &[String], target: &str) {
+    let mut w = CodeWriter::two_space().with_depth(indent.len() / 2);
+    let a = &slots[0];
+    // Optional aggregates share the plain aggregate decoding: the readers
+    // decode a null base to an empty aggregate (matching the async path).
+    let ty = match ty {
+        TypeRef::Optional(inner)
+            if matches!(
+                inner.as_ref(),
+                TypeRef::Bytes | TypeRef::BorrowedBytes | TypeRef::List(_) | TypeRef::Map(_, _)
+            ) =>
+        {
+            inner.as_ref()
+        }
+        other => other,
+    };
+    match ty {
+        TypeRef::Bool => {
+            w.line(format!("const {target} = {a} !== 0;"));
+        }
+        TypeRef::I8
+        | TypeRef::I16
+        | TypeRef::I32
+        | TypeRef::U8
+        | TypeRef::U16
+        | TypeRef::U32
+        | TypeRef::I64
+        | TypeRef::U64
+        | TypeRef::F32
+        | TypeRef::F64
+        | TypeRef::Handle
+        | TypeRef::Enum(_) => {
+            w.line(format!("const {target} = {a};"));
+        }
+        TypeRef::StringUtf8 | TypeRef::BorrowedStr => {
+            w.line(format!("const {target} = _readCStr(wasm, {a});"));
+        }
+        TypeRef::Bytes | TypeRef::BorrowedBytes => {
+            let b = &slots[1];
+            w.line(format!(
+                "const {target} = ({a} === 0 || {b} === 0) ? new Uint8Array(0) : new Uint8Array(wasm.memory.buffer, {a}, {b}).slice();"
+            ));
+        }
+        TypeRef::Record(name) | TypeRef::RichEnum(name) | TypeRef::TypedHandle(name) => {
+            let cls = local_type_name(name);
+            w.line(format!("const {target} = new {cls}(wasm, {a});"));
+        }
+        TypeRef::Interface(name) => {
+            let cls = local_type_name(name);
+            w.line(format!("const {target} = {cls}._wrap({a});"));
+        }
+        TypeRef::List(inner) => {
+            let mut tmp = String::new();
+            emit_read_list_into(
+                &mut tmp,
+                indent,
+                inner,
+                a,
+                &slots[1],
+                target,
+                ElemOwnership::Borrowed,
+            );
+            w.raw(tmp);
+        }
+        TypeRef::Map(k, v) => {
+            let mut tmp = String::new();
+            emit_read_map_into(
+                &mut tmp,
+                indent,
+                k,
+                v,
+                a,
+                &slots[1],
+                &slots[2],
+                target,
+                ElemOwnership::Borrowed,
+            );
+            w.raw(tmp);
+        }
+        TypeRef::Optional(inner) => match inner.as_ref() {
+            TypeRef::StringUtf8 | TypeRef::BorrowedStr => {
+                w.line(format!("const {target} = _readCStr(wasm, {a});"));
+            }
+            TypeRef::Record(name) | TypeRef::RichEnum(name) | TypeRef::TypedHandle(name) => {
+                let cls = local_type_name(name);
+                w.line(format!(
+                    "const {target} = {a} === 0 ? null : new {cls}(wasm, {a});"
+                ));
+            }
+            TypeRef::Interface(name) => {
+                let cls = local_type_name(name);
+                w.line(format!(
+                    "const {target} = {a} === 0 ? null : {cls}._wrap({a});"
+                ));
+            }
+            scalar => {
+                // Boxed optional scalar: the box is borrowed, so dereference
+                // without freeing.
+                let read = wasm_read_scalar_elem(scalar, "new DataView(wasm.memory.buffer)", a, "0")
+                    .replace(&format!("{a} + 0 * {}", wasm_stride(scalar)), a);
+                w.line(format!("const {target} = {a} === 0 ? null : {read};"));
+            }
+        },
+        TypeRef::Iterator(_) => unreachable!("iterator not valid as callback parameter"),
+        TypeRef::Named(_) => unreachable!("unresolved type reference"),
+    }
+    out.push_str(&w.finish());
+}
+
+/// Emit the long-lived trampoline for one callback typedef at `indent`
+/// (loader scope). The trampoline's wasm signature mirrors the callback's ABI
+/// slots (the trailing `void* context` slot carries the subscription's
+/// context id); it looks up the subscription, decodes each argument per the
+/// borrowing contract, and invokes the JS callback synchronously.
+fn emit_js_listener_trampoline(out: &mut String, cb: &CallbackBinding, indent: &str) {
+    let tramp = js_listener_tramp_name(&cb.c_fn_type);
+    let param_types: Vec<String> = cb
+        .abi_params
+        .iter()
+        .map(|p| format!("'{}'", cb_slot_wasm_type(&p.ty)))
+        .collect();
+    // Positional slot names: one per ABI slot, with the trailing context slot
+    // named _ctx.
+    let mut slot_names: Vec<String> = (0..cb.abi_params.len() - 1)
+        .map(|i| format!("a{i}"))
+        .collect();
+    slot_names.push("_ctx".to_string());
+
+    let mut w = CodeWriter::two_space().with_depth(indent.len() / 2);
+    w.block(
+        format!(
+            "const {tramp} = _registerTrampoline(_table, [{}], ({}) => {{",
+            param_types.join(", "),
+            slot_names.join(", ")
+        ),
+        "});",
+        |w| {
+            w.line("const _l = _listeners.get(_ctx);");
+            w.line("if (_l === undefined) return;");
+            let inner = w.indent_str();
+            let mut slot_idx = 0usize;
+            let mut call_args: Vec<String> = Vec::new();
+            for (i, p) in cb.params.iter().enumerate() {
+                let n = p.abi.len();
+                let slots = &slot_names[slot_idx..slot_idx + n];
+                slot_idx += n;
+                let target = format!("_p{i}");
+                let mut tmp = String::new();
+                emit_cb_param_decode(&mut tmp, &inner, &p.ty, slots, &target);
+                w.raw(tmp);
+                call_args.push(target);
+            }
+            w.line(format!("_l.callback({});", call_args.join(", ")));
+        },
+    );
+    out.push_str(&w.finish());
+}
+
+/// Emit one listener's register/unregister pair as module-object members.
+///
+/// `register` allocates a context id, hands the shared trampoline and that id
+/// to the producer's `register_*` symbol, and returns the context id as the
+/// consumer-facing subscription id (a plain number; the producer's `uint64_t`
+/// id stays internal so the public surface avoids `BigInt`). `unregister`
+/// releases both sides and is a no-op for an unknown id.
+fn emit_js_listener_api(out: &mut String, l: &ListenerBinding, indent: &str) {
+    let tramp = js_listener_tramp_name(&l.callback_c_fn_type);
+    let register_name = format!("register_{}", l.name).to_lower_camel_case();
+    let unregister_name = format!("unregister_{}", l.name).to_lower_camel_case();
+    let mut w = CodeWriter::two_space().with_depth(indent.len() / 2);
+    let mut doc = String::new();
+    emit_doc(&mut doc, &l.doc, indent);
+    w.raw(doc);
+    w.block(format!("{register_name}(callback) {{"), "},", |w| {
+        w.line("const _id = _nextLsnId++;");
+        w.line(format!(
+            "const _rid = wasm.{}({tramp}, _id);",
+            l.register_symbol
+        ));
+        w.line("_listeners.set(_id, { callback, rid: _rid });");
+        w.line("return _id;");
+    });
+    w.block(format!("{unregister_name}(id) {{"), "},", |w| {
+        w.line("const _l = _listeners.get(id);");
+        w.line("if (_l === undefined) return;");
+        w.line("_listeners.delete(id);");
+        w.line(format!("wasm.{}(_l.rid);", l.unregister_symbol));
+    });
     out.push_str(&w.finish());
 }
 
@@ -3734,8 +4080,9 @@ mod tests {
         }])
     }
 
-    /// An API with a callback + listener, which the wasm target declares
-    /// unsupported.
+    /// An API with a callback + listener, delivered synchronously through a
+    /// long-lived function-table trampoline in the standard loader (and
+    /// stubbed in Emscripten mode).
     fn listener_api() -> Api {
         make_api(vec![Module {
             name: "events".into(),
@@ -3779,29 +4126,13 @@ mod tests {
     }
 
     #[test]
-    fn capabilities_declare_callbacks_and_listeners_unsupported() {
+    fn capabilities_declare_full_support() {
         let caps = LanguageBackend::capabilities(&WasmGenerator);
-        assert!(caps.async_functions);
-        assert!(caps.iterators);
-        assert!(!caps.callbacks);
-        assert!(!caps.listeners);
+        assert_eq!(caps, TargetCapabilities::full());
     }
 
     #[test]
-    fn allow_unsupported_flag_flows_from_config() {
-        assert!(!LanguageBackend::allows_unsupported(
-            &WasmGenerator,
-            &WasmConfig::default()
-        ));
-        let cfg = WasmConfig {
-            allow_unsupported: true,
-            ..WasmConfig::default()
-        };
-        assert!(LanguageBackend::allows_unsupported(&WasmGenerator, &cfg));
-    }
-
-    #[test]
-    fn listeners_emit_throwing_stubs_in_js() {
+    fn listeners_emit_register_unregister_in_js() {
         let js = js_stub_for(
             &listener_api(),
             DEFAULT_MODULE_NAME,
@@ -3810,16 +4141,35 @@ mod tests {
             "weaveffi_wasm.js",
             false,
         );
-        assert!(js.contains("registerMessageListener() {"), "{js}");
-        assert!(js.contains("unregisterMessageListener() {"), "{js}");
+        // One long-lived trampoline per callback typedef, in the function
+        // table, decoding the borrowed string argument without freeing it.
         assert!(
-            js.contains("listener 'message_listener' is not supported by the wasm target"),
+            js.contains(
+                "const _lsnPtr_weaveffi_events_OnMessage_fn = _registerTrampoline(_table, ['i32', 'i32'],"
+            ),
             "{js}"
         );
+        assert!(js.contains("const _p0 = _readCStr(wasm, a0);"), "{js}");
+        assert!(js.contains("_l.callback(_p0);"), "{js}");
+        // Register hands the trampoline and a context id to the producer and
+        // returns the numeric context id; unregister releases both sides.
+        assert!(js.contains("registerMessageListener(callback) {"), "{js}");
+        assert!(
+            js.contains(
+                "wasm.weaveffi_events_register_message_listener(_lsnPtr_weaveffi_events_OnMessage_fn, _id)"
+            ),
+            "{js}"
+        );
+        assert!(js.contains("unregisterMessageListener(id) {"), "{js}");
+        assert!(
+            js.contains("wasm.weaveffi_events_unregister_message_listener(_l.rid);"),
+            "{js}"
+        );
+        assert!(!js.contains("is not supported"), "{js}");
     }
 
     #[test]
-    fn listeners_omitted_from_dts() {
+    fn listeners_declared_in_dts() {
         let api = listener_api();
         let dts = dts_for(
             &api,
@@ -3828,23 +4178,76 @@ mod tests {
             "weaveffi_wasm.d.ts",
             false,
         );
-        assert!(!dts.contains("register_message_listener"), "{dts}");
+        assert!(
+            dts.contains("registerMessageListener(callback: (message: string) => void): number;"),
+            "{dts}"
+        );
+        assert!(
+            dts.contains("unregisterMessageListener(id: number): void;"),
+            "{dts}"
+        );
         assert!(dts.contains("send(text: string)"), "{dts}");
     }
 
     #[test]
-    fn readme_documents_unsupported_features() {
+    fn readme_documents_listeners() {
         let readme = readme_for(&listener_api(), "weaveffi", "weaveffi.yml", false);
-        assert!(readme.contains("## Unsupported Features"), "{readme}");
-        assert!(readme.contains("events.message_listener"), "{readme}");
-        assert!(readme.contains("events.OnMessage"), "{readme}");
-        assert!(readme.contains("throw on call"), "{readme}");
+        assert!(readme.contains("### Callbacks and Listeners"), "{readme}");
+        assert!(readme.contains("synchronous"), "{readme}");
+        assert!(readme.contains("subscription id"), "{readme}");
+        assert!(!readme.contains("## Unsupported Features"), "{readme}");
     }
 
     #[test]
-    fn supported_only_api_has_no_unsupported_section() {
+    fn listener_free_api_has_no_listener_section() {
         let readme = readme_for(&sample_api(), "weaveffi", "weaveffi.yml", false);
-        assert!(!readme.contains("## Unsupported Features"));
+        assert!(!readme.contains("### Callbacks and Listeners"));
+    }
+
+    #[test]
+    fn listeners_emit_throwing_stubs_in_emscripten_mode() {
+        let js = js_stub_for(
+            &listener_api(),
+            DEFAULT_MODULE_NAME,
+            "weaveffi",
+            "weaveffi.yml",
+            "weaveffi_wasm.js",
+            true,
+        );
+        assert!(js.contains("registerMessageListener() {"), "{js}");
+        assert!(js.contains("unregisterMessageListener() {"), "{js}");
+        assert!(
+            js.contains("listener 'message_listener' is not supported in Emscripten mode"),
+            "{js}"
+        );
+        assert!(
+            !js.contains("_lsnPtr_") && !js.contains("_listeners"),
+            "no listener machinery in Emscripten mode: {js}"
+        );
+    }
+
+    #[test]
+    fn listeners_omitted_from_dts_in_emscripten_mode() {
+        let api = listener_api();
+        let dts = dts_for(
+            &api,
+            DEFAULT_MODULE_NAME,
+            "weaveffi.yml",
+            "weaveffi_wasm.d.ts",
+            true,
+        );
+        assert!(!dts.contains("registerMessageListener"), "{dts}");
+        assert!(dts.contains("send(text: string)"), "{dts}");
+    }
+
+    #[test]
+    fn readme_documents_listener_gap_in_emscripten_mode() {
+        let readme = readme_for(&listener_api(), "weaveffi", "weaveffi.yml", true);
+        assert!(readme.contains("## Callbacks and Listeners"), "{readme}");
+        assert!(
+            readme.contains("not supported in Emscripten mode"),
+            "{readme}"
+        );
     }
 
     #[test]

--- a/crates/weaveffi-gen-wasm/src/lib.rs
+++ b/crates/weaveffi-gen-wasm/src/lib.rs
@@ -15,8 +15,8 @@ use std::fmt::Write as _;
 use camino::Utf8Path;
 use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToUpperCamelCase};
 use serde::{Deserialize, Serialize};
-use weaveffi_core::backend::{LanguageBackend, OutputFile};
 use weaveffi_core::abi::CType;
+use weaveffi_core::backend::{LanguageBackend, OutputFile};
 use weaveffi_core::capabilities::TargetCapabilities;
 use weaveffi_core::codegen::common::{
     emit_doc as common_emit_doc, walk_modules, walk_modules_with_path, DocCommentStyle,
@@ -2860,7 +2860,13 @@ fn js_listener_tramp_name(c_fn_type: &str) -> String {
 /// buffers are copied out of linear memory and never freed here, and opaque
 /// pointers (records, rich enums, interfaces) are wrapped without taking
 /// ownership.
-fn emit_cb_param_decode(out: &mut String, indent: &str, ty: &TypeRef, slots: &[String], target: &str) {
+fn emit_cb_param_decode(
+    out: &mut String,
+    indent: &str,
+    ty: &TypeRef,
+    slots: &[String],
+    target: &str,
+) {
     let mut w = CodeWriter::two_space().with_depth(indent.len() / 2);
     let a = &slots[0];
     // Optional aggregates share the plain aggregate decoding: the readers
@@ -2958,8 +2964,9 @@ fn emit_cb_param_decode(out: &mut String, indent: &str, ty: &TypeRef, slots: &[S
             scalar => {
                 // Boxed optional scalar: the box is borrowed, so dereference
                 // without freeing.
-                let read = wasm_read_scalar_elem(scalar, "new DataView(wasm.memory.buffer)", a, "0")
-                    .replace(&format!("{a} + 0 * {}", wasm_stride(scalar)), a);
+                let read =
+                    wasm_read_scalar_elem(scalar, "new DataView(wasm.memory.buffer)", a, "0")
+                        .replace(&format!("{a} + 0 * {}", wasm_stride(scalar)), a);
                 w.line(format!("const {target} = {a} === 0 ? null : {read};"));
             }
         },

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -263,15 +263,20 @@ references are all **first-class**. They pass validation and every
 generator handles them. Do not re-add validator rejections for these
 features.
 
-The one exception is per-target capability gating: each generator
-declares a `TargetCapabilities` (async, callbacks, listeners,
+Per-target capability gating still exists as a mechanism: each
+generator declares a `TargetCapabilities` (async, callbacks, listeners,
 iterators), and the orchestrator fails generation (listing the
 offending IDL definitions) when a selected target cannot deliver a
-used feature. Today only Wasm declares gaps (callbacks and listeners);
-its `allow_unsupported = true` config opts into generating the rest of
-the surface with explicit throwing stubs in place of the unsupported
-entry points. Capability failures must stay loud: never skip a
-definition silently.
+used feature. Today every shipped target declares full support, so the
+gate only fires if a future target (or a new gated feature) introduces
+a gap; a partial target's `allow_unsupported = true` config would opt
+into generating the rest of the surface with explicit throwing stubs in
+place of the unsupported entry points. The Wasm generator's Emscripten
+mode is the one place stubs still appear: async functions, callbacks,
+and listeners become explicit throwing stubs there (and are omitted
+from the TypeScript declarations) because Emscripten modules do not
+portably expose the trampoline machinery. Capability failures and mode
+gaps must stay loud: never skip a definition silently.
 
 ## Generator configuration resolution
 

--- a/docs/src/generators/README.md
+++ b/docs/src/generators/README.md
@@ -25,7 +25,7 @@ uses a feature the selected target cannot deliver (no silent skips).
 | Dart | ✓ (`Future<T>`) | ✓ | ✓ (`NativeCallable`) | ✓ |
 | Go | ✓ (blocking bridge) | ✓ | ✓ (exported trampolines) | ✓ |
 | Ruby | ✓ (blocking bridge) | ✓ | ✓ (`FFI::Function`) | ✓ |
-| Wasm | ✓ (`Promise<T>`) | ✓ | ✗ | ✗ |
+| Wasm | ✓ (`Promise<T>`) | ✓ | ✓ (table trampolines) | ✓ |
 
 Notes:
 
@@ -40,9 +40,13 @@ Notes:
   producer's completion callback fires (a channel receive in Go, a
   `Queue#pop` in Ruby). Run them from a goroutine or Ruby thread for
   concurrency; the native producer still runs off-thread.
-- **Wasm callbacks/listeners** are unsupported: a
-  `wasm32-unknown-unknown` module is single-threaded and has no producer
-  thread to deliver events. Generation fails unless you opt in with
-  `allow_unsupported = true` ([details](wasm.md#capabilities-and-allow_unsupported)),
-  in which case the unsupported entry points become explicit throwing
-  stubs rather than silent no-ops.
+- **Wasm callbacks/listeners deliver synchronously.** The loader
+  installs one long-lived JavaScript trampoline per callback typedef in
+  the module's function table, so the producer's `emit_*` dispatches
+  straight back into JS. Because `wasm32-unknown-unknown` is
+  single-threaded, events fire only while a call into the module is on
+  the stack; a producer that emits from a spawned thread cannot run on
+  this target at all ([details](wasm.md#callbacks-and-listeners)). In
+  [Emscripten mode](wasm.md#emscripten-mode) callbacks, listeners, and
+  async functions become explicit throwing stubs rather than silent
+  no-ops.

--- a/docs/src/generators/wasm.md
+++ b/docs/src/generators/wasm.md
@@ -12,9 +12,10 @@ linear memory. TypeScript declarations describe the whole surface.
 C and C++ producers compiled with Emscripten are supported through a
 dedicated loader variant; see [Emscripten mode](#emscripten-mode).
 
-Because a `wasm32-unknown-unknown` module is single-threaded and has no
-producer thread, **callbacks and listeners are not supported**; see
-[Capabilities and `allow_unsupported`](#capabilities-and-allow_unsupported).
+Callbacks and listeners are supported with **synchronous, same-thread
+delivery**: a `wasm32-unknown-unknown` module is single-threaded, so
+events fire only while a call into the module is on the stack; see
+[Callbacks and listeners](#callbacks-and-listeners).
 
 ## What gets generated
 
@@ -418,33 +419,84 @@ checker and throws the typed `KvError` subclasses; a non-throwing one
 like `getMessages` throws the generic `WeaveFFIError` only for
 producer bugs. The TypeScript declaration is `IterableIterator<T>`.
 
-## Capabilities and `allow_unsupported`
+## Callbacks and listeners
 
-The Wasm generator declares callbacks and listeners as unsupported in
-its `TargetCapabilities`. If your IDL uses them, `weaveffi generate`
-fails with an error listing the offending definitions rather than
-silently skipping them.
+Each listener surfaces on its module namespace as a
+`register.../unregister...` pair. `register` takes a plain JavaScript
+function and returns a numeric subscription id; `unregister` takes that
+id and stops delivery. From the `events` sample:
 
-To generate the rest of the surface anyway, opt in explicitly:
+```js
+const received = [];
+const sub = api.events.registerMessageListener((message) => received.push(message));
 
-```toml
-# weaveffi.toml
-[wasm]
-allow_unsupported = true
+api.events.sendMessage('alpha'); // emit_message_listener fires synchronously
+console.log(received);           // ['alpha']
+
+api.events.unregisterMessageListener(sub);
 ```
 
-or inline in the IDL:
+Under the hood the loader reuses the async machinery: it installs one
+long-lived trampoline per callback typedef in the module's
+`__indirect_function_table` (via `WebAssembly.Function`, the same
+[JS Type Reflection API](https://github.com/WebAssembly/js-types)
+dependency async functions have) and hands the trampoline's table index
+plus a per-subscription context id to the producer's `register_*`
+symbol. When the producer's `emit_*` helper fires, the trampoline looks
+up the subscription by context id, decodes each argument, and invokes
+the JavaScript callback:
 
-```yaml
-generators:
-  wasm:
-    allow_unsupported: true
+```js
+let _nextLsnId = 1;
+const _listeners = new Map();
+
+const _lsnPtr_weaveffi_events_OnMessage_fn = _registerTrampoline(_table, ['i32', 'i32'], (a0, _ctx) => {
+  const _l = _listeners.get(_ctx);
+  if (_l === undefined) return;
+  const _p0 = _readCStr(wasm, a0);
+  _l.callback(_p0);
+});
+
+// On the module object:
+registerMessageListener(callback) {
+  const _id = _nextLsnId++;
+  const _rid = wasm.weaveffi_events_register_message_listener(_lsnPtr_weaveffi_events_OnMessage_fn, _id);
+  _listeners.set(_id, { callback, rid: _rid });
+  return _id;
+},
+unregisterMessageListener(id) {
+  const _l = _listeners.get(id);
+  if (_l === undefined) return;
+  _listeners.delete(id);
+  wasm.weaveffi_events_unregister_message_listener(_l.rid);
+},
 ```
 
-With the opt-in, unsupported entry points are generated as **explicit
-throwing stubs** (calling `registerMessageListener` throws an
-`Error` explaining that listeners need a native target), so the gap is
-visible at the call site instead of failing silently.
+One trampoline serves every subscription to callbacks of the same
+typedef (the context id disambiguates), so register/unregister churn
+never grows the function table. The producer's `uint64_t` subscription
+id stays internal to the loader; the public surface deals only in plain
+numbers.
+
+Two semantic points to keep in mind:
+
+- **Delivery is synchronous and same-thread.** The target is
+  single-threaded, so `emit_*` can only run while a call into the
+  module is on the stack, and your callback runs before that call
+  returns. This is not a limitation of the bindings: a producer that
+  emits from a spawned thread cannot run on `wasm32-unknown-unknown`
+  at all (`std::thread::spawn` fails there).
+- **Callback arguments are borrowed.** The producer owns every argument
+  for the duration of the dispatch. Strings and byte buffers are copied
+  into JavaScript values before your callback runs, but struct,
+  rich-enum, and interface arguments wrap producer-owned memory: read
+  what you need inside the callback and do not retain the wrapper or
+  call `free()` on it.
+
+In [Emscripten mode](#emscripten-mode) callbacks and listeners are not
+supported; each register/unregister entry point becomes an explicit
+throwing stub and is omitted from the TypeScript declarations, exactly
+like async functions in that mode.
 
 ## Emscripten mode
 
@@ -525,13 +577,13 @@ writes linear memory through `Module['HEAPU8']`.
 
 ### Limitations
 
-Async functions are not supported in Emscripten mode. The trampoline
-registration in the standard loader relies on `WebAssembly.Function`
-and a growable `__indirect_function_table`, neither of which an
-Emscripten module exposes portably. Each async entry point becomes an
-explicit stub that throws at call time and is omitted from the
-TypeScript declarations. Callbacks and listeners stay unsupported
-exactly as in the standard mode.
+Async functions, callbacks, and listeners are not supported in
+Emscripten mode. The trampoline registration in the standard loader
+relies on `WebAssembly.Function` and a growable
+`__indirect_function_table`, neither of which an Emscripten module
+exposes portably. Each async, register, and unregister entry point
+becomes an explicit stub that throws at call time and is omitted from
+the TypeScript declarations.
 
 ## Build instructions
 
@@ -573,7 +625,7 @@ Serve it over HTTP and load it with the generated helper:
 
 - **`WebAssembly.Function is not a constructor`**: the runtime lacks
   JS Type Reflection. Use a current Chrome/Firefox/Node/Deno, or avoid
-  async IDL functions for this target.
+  async functions, callbacks, and listeners for this target.
 - **`LinkError: import object field 'env' is not a Function`**: the
   loader instantiates with an empty imports object. If your Rust crate
   imports host functions, extend `loadWeaveffiWasm` to pass them in.
@@ -582,6 +634,10 @@ Serve it over HTTP and load it with the generated helper:
 - **An async call never settles**: the producer must invoke the
   completion callback on the same thread; `std::thread::spawn` does not
   exist on `wasm32-unknown-unknown`.
+- **A registered listener never fires**: delivery is synchronous, so
+  events arrive only while a call into the module is on the stack. The
+  producer must `emit_*` during one of your calls; there is no
+  background delivery on this target.
 - **Out-of-memory after many `_raw` calls**: every pointer returned
   from the module must be deallocated; the typed wrappers do this for
   you, raw calls do not.

--- a/docs/src/guides/config.md
+++ b/docs/src/guides/config.md
@@ -171,8 +171,7 @@ the keys are identical.
 | `[node]`    | `package_name`         | string | `"weaveffi"`       | npm package name in the Node.js loader                                      |
 | `[node]`    | `strip_module_prefix`  | bool   | `true`             | Strip the IR module prefix from emitted JS/TS symbols                       |
 | `[wasm]`    | `module_name`          | string | `"weaveffi_wasm"`  | Module name in the Wasm JS loader                                           |
-| `[wasm]`    | `allow_unsupported`    | bool   | `false`            | Generate anyway when the IDL uses features Wasm cannot deliver (callbacks, listeners); unsupported entry points become explicit throwing stubs |
-| `[wasm]`    | `emscripten`           | bool   | `false`            | Target an Emscripten build: the loader accepts a pre-initialized Emscripten `Module` (or its `MODULARIZE` factory promise) instead of a `.wasm` URL; async functions become throwing stubs |
+| `[wasm]`    | `emscripten`           | bool   | `false`            | Target an Emscripten build: the loader accepts a pre-initialized Emscripten `Module` (or its `MODULARIZE` factory promise) instead of a `.wasm` URL; async functions, callbacks, and listeners become throwing stubs |
 | `[c]`       | `prefix`               | string | `"weaveffi"`       | Prefix prepended to every C ABI symbol (`{prefix}_{module}_{function}`)     |
 | `[cpp]`     | `namespace`            | string | `"weaveffi"`       | C++ namespace for the wrapper                                               |
 | `[cpp]`     | `header_name`          | string | `"weaveffi.hpp"`   | Header file name for the C++ output                                         |

--- a/docs/src/samples.md
+++ b/docs/src/samples.md
@@ -38,9 +38,9 @@ real-world pattern for a new generator.
 - A deprecated method (`legacy_put`)
 - A nested sub-module (`kv.stats`) with its own struct (`Stats`) and a function
   that takes a cross-module `Store` parameter
-- Inline `generators:` overrides for `wasm.allow_unsupported`,
-  `swift.module_name`, `cpp.namespace`, `dotnet.namespace`,
-  `dart.package_name`, `go.module_path`, and `ruby.module_name`
+- Inline `generators:` overrides for `swift.module_name`,
+  `cpp.namespace`, `dotnet.namespace`, `dart.package_name`,
+  `go.module_path`, and `ruby.module_name`
 
 **Build, generate bindings, and run the C ABI tests:**
 

--- a/samples/events/events.yml
+++ b/samples/events/events.yml
@@ -26,9 +26,3 @@ modules:
         doc: Return an iterator over all sent messages
         params: []
         return: "iter<string>"
-generators:
-  # The wasm target cannot deliver producer-initiated callbacks/listeners
-  # (single-threaded, no producer thread); opt in to generating the rest of
-  # the surface; message_listener becomes an explicit throwing stub.
-  wasm:
-    allow_unsupported: true

--- a/samples/kvstore/kvstore.yml
+++ b/samples/kvstore/kvstore.yml
@@ -126,11 +126,6 @@ modules:
             return: Stats
             throws: true
 generators:
-  # The wasm target cannot deliver producer-initiated callbacks/listeners
-  # (single-threaded, no producer thread); opt in to generating the rest of
-  # the surface; the eviction listener becomes an explicit throwing stub.
-  wasm:
-    allow_unsupported: true
   ruby:
     module_name: Kvstore
   dotnet:


### PR DESCRIPTION
## Summary

The Wasm generator now implements callbacks and listeners instead of declaring them unsupported. The loader reuses the async machinery: it installs one long-lived `WebAssembly.Function` trampoline per callback typedef in the module's `__indirect_function_table` and hands its table index plus a per-subscription context id to the producer's `register_*` symbol, so `emit_*` dispatches synchronously back into JavaScript. Delivery is same-thread by construction (`wasm32-unknown-unknown` is single-threaded; a producer that emits from a spawned thread cannot run on this target at all), which is exactly the pattern the samples use, so the "no producer thread" rationale for the old gap did not hold for same-thread emission. `TargetCapabilities` flips to full, `registerXxxListener(callback)` returns a plain numeric subscription id (the producer's `uint64_t` id stays internal, keeping `BigInt` out of the public surface), and the `.d.ts` declares the typed register/unregister pair. Emscripten mode keeps explicit throwing stubs, mirroring its async precedent.

## Changes

- Emit per-callback-typedef trampolines, a context-id subscription map, and real `register.../unregister...` wrappers in the standard loader; decode borrowed callback arguments per the marshalling table (strings/bytes copied without freeing, records/interfaces wrapped without ownership, scalars, optionals, lists, and maps covered).
- Declare full `TargetCapabilities`, update the CLI capability-matrix pin, and remove the now-unneeded `allow_unsupported` field from `WasmConfig` (breaking for library consumers; old YAML carrying the flag still parses and is inert).
- Keep listener entry points as explicit throwing stubs in Emscripten mode and omit them from the TypeScript declarations, matching the async-function precedent.
- Drop the `wasm.allow_unsupported` opt-in from the events and kvstore samples; rewrite the wasm conformance consumers to assert real synchronous delivery (register, emit fires inside the call, unregister stops delivery) instead of asserting that stubs throw.
- Update unit and CLI integration tests, regenerate 13 wasm snapshots, and refresh the docs (feature matrix, architecture capability-gating notes, wasm generator guide with a new "Callbacks and listeners" section, config table, and generated READMEs).

Closes #31

BREAKING CHANGE: `WasmConfig` no longer has an `allow_unsupported` field; the wasm target supports every gated feature, so the opt-in is gone. An `allow_unsupported: true` entry in existing IDL/TOML config is ignored.
